### PR TITLE
feat: Version calculation

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,5 +1,8 @@
 mode: Mainline
 
+merge-message-formats:
+  ghmerge: ^Merge pull request \#(?<PullRequestNumber>\d+) from (?<SourceBranch>.+)
+
 major-version-bump-message: "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\\([\\w\\s-]*\\))?(!:|:.*\\n\\n((.+\\n)+\\n)?BREAKING CHANGE:\\s.+)"
 minor-version-bump-message: "^(feat)(\\([\\w\\s-]*\\))?:"
 patch-version-bump-message: "^(build|chore|ci|docs|fix|perf|refactor|revert|style|test)(\\([\\w\\s-]*\\))?:"

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,2 +1,7 @@
 mode: Mainline
 
+major-version-bump-message: "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\\([\\w\\s-]*\\))?(!:|:.*\\n\\n((.+\\n)+\\n)?BREAKING CHANGE:\\s.+)"
+minor-version-bump-message: "^(feat)(\\([\\w\\s-]*\\))?:"
+patch-version-bump-message: "^(build|chore|ci|docs|fix|perf|refactor|revert|style|test)(\\([\\w\\s-]*\\))?:"
+
+commit-message-incrementing: MergeMessageOnly


### PR DESCRIPTION
Follow the Conventional Commits standard (https://www.conventionalcommits.org/en/v1.0.0/) when bumping version numbers.

Also, only calculate based on the merge commit message.