### PR TITLE
Docker: Upgrade Alpine to 1.18 and add bash to container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,12 +22,12 @@ RUN apk add --update ccache \
     && strip build/porla
 
 # -- runtime layer
-FROM alpine:3.17.0 AS runtime
+FROM alpine:3.18.0 AS runtime
 
 ENV PORLA_HTTP_HOST=0.0.0.0
 EXPOSE 1337
 
-RUN apk --no-cache add curl
+RUN apk --no-cache add curl bash
 WORKDIR /
 COPY --from=build-env /src/build/porla /usr/bin/porla
 ENTRYPOINT [ "/usr/bin/porla" ]


### PR DESCRIPTION
Alpine upgrade to 1.18 is useful due to TCP fallback support finally in DNS resolver.
https://alpinelinux.org/posts/Alpine-3.18.0-released.html

Idea behind adding bash as well is so that debugging would be easier in the container.