### PR TITLE
feat(http): add TYPE, HELP and timestamp to metrics endpoint

### DIFF
--- a/src/http/metricshandler.cpp
+++ b/src/http/metricshandler.cpp
@@ -1,15 +1,22 @@
 #include "metricshandler.hpp"
 
 #include <boost/signals2.hpp>
+#include <libtorrent/session_stats.hpp>
 
 #include "../sessions.hpp"
 
 using porla::Http::MetricsHandler;
 
+static std::map<std::string, std::string> MetricHelp =
+{
+    {"", ""}
+};
+
 class MetricsHandler::State
 {
 public:
     explicit State(Sessions& sessions)
+        : m_stats(lt::session_stats_metrics())
     {
         m_stats_connection = sessions.OnSessionStats([this](auto && p1, auto && p2) { OnSessionStats(p1, p2); });
     }
@@ -19,24 +26,32 @@ public:
         m_stats_connection.disconnect();
     }
 
-    std::map<std::string, std::map<std::string, int64_t>>& Stats()
+    std::map<std::string, std::pair<std::uint64_t, lt::span<const int64_t>>>& SessionCounters()
+    {
+        return m_session_counters;
+    }
+
+    std::vector<lt::stats_metric>& StatsMetrics()
     {
         return m_stats;
     }
 
 private:
-    void OnSessionStats(const std::string& session, const std::map<std::string, int64_t>& stats)
+    void OnSessionStats(const std::string& session, const lt::span<const int64_t>& stats)
     {
-        if (m_stats.find(session) == m_stats.end())
+        if (m_session_counters.find(session) == m_session_counters.end())
         {
-            m_stats.insert({ session, {} });
+            m_session_counters.insert({ session, {} });
         }
 
-        m_stats.at(session) = stats;
+        uint64_t ms = duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+
+        m_session_counters.at(session) = { ms, stats};
     }
 
     boost::signals2::connection m_stats_connection;
-    std::map<std::string, std::map<std::string, int64_t>> m_stats;
+    std::map<std::string, std::pair<std::uint64_t, lt::span<const int64_t>>> m_session_counters;
+    std::vector<lt::stats_metric> m_stats;
 };
 
 MetricsHandler::MetricsHandler(porla::Sessions& sessions)
@@ -46,19 +61,48 @@ MetricsHandler::MetricsHandler(porla::Sessions& sessions)
 
 MetricsHandler::~MetricsHandler() = default;
 
-void MetricsHandler::operator()(uWS::HttpResponse<false>* res, uWS::HttpRequest* req)
+void MetricsHandler::operator()(uWS::HttpResponse<false>* res, [[maybe_unused]] uWS::HttpRequest* req)
 {
     std::stringstream out;
 
-    for (const auto& [session, stats] : m_state->Stats())
+    for (const auto& metric : m_state->StatsMetrics())
     {
-        for (const auto& [key, val] : stats)
-        {
-            std::string key_replaced = key;
-            std::replace(key_replaced.begin(), key_replaced.end(), '.', '_');
+        std::string key_replaced = metric.name;
+        std::replace(key_replaced.begin(), key_replaced.end(), '.', '_');
 
-            out << "libtorrent_" << key_replaced << "{session=\"" << session << "\"} " << val << "\n";
+        // # HELP
+        // # TYPE
+
+        const auto help = MetricHelp.find(metric.name);
+
+        if (help != MetricHelp.end())
+        {
+            out << "# HELP libtorrent_" << key_replaced << " " << help->second << "\n";
         }
+
+        switch (metric.type)
+        {
+            case libtorrent::metric_type_t::counter:
+                out << "# TYPE libtorrent_" << key_replaced << " counter\n";
+                break;
+            case libtorrent::metric_type_t::gauge:
+                out << "# TYPE libtorrent_" << key_replaced << " gauge\n";
+                break;
+        }
+
+        for (const auto& [ session, counters ] : m_state->SessionCounters())
+        {
+            if (counters.first == 0)
+            {
+                continue;
+            }
+
+            const auto counter_value = counters.second[metric.value_index];
+
+            out << "libtorrent_" << key_replaced << "{session=\"" << session << "\"} " << counter_value << " " << counters.first << "\n";
+        }
+
+        out << "\n";
     }
 
     res->writeStatus("200 OK")->end(out.str());

--- a/src/http/metricshandler.hpp
+++ b/src/http/metricshandler.hpp
@@ -17,7 +17,7 @@ namespace porla::Http
         explicit MetricsHandler(Sessions& sessions);
         ~MetricsHandler();
 
-        void operator()(uWS::HttpResponse<false>* res, uWS::HttpRequest* req);
+        void operator()(uWS::HttpResponse<false>* res, [[maybe_unused]] uWS::HttpRequest* req);
 
     private:
         class State;

--- a/src/sessions.hpp
+++ b/src/sessions.hpp
@@ -50,7 +50,7 @@ namespace porla
         };
 
         typedef boost::signals2::signal<void(const std::string& session, const libtorrent::info_hash_t&)> InfoHashSignal;
-        typedef boost::signals2::signal<void(const std::string& session, const std::map<std::string, int64_t>&)> SessionStatsSignal;
+        typedef boost::signals2::signal<void(const std::string& session, const lt::span<const int64_t>&)> SessionStatsSignal;
         typedef boost::signals2::signal<void(const std::string& session, const libtorrent::torrent_handle&)> TorrentHandleSignal;
         typedef boost::signals2::signal<void(const std::string& session, const libtorrent::torrent_status&)> TorrentStatusSignal;
         typedef boost::signals2::signal<void(const std::string& session, const std::vector<libtorrent::torrent_status>&)> TorrentStatusListSignal;
@@ -115,7 +115,6 @@ namespace porla
 
         SessionsOptions m_options;
         std::map<std::string, std::shared_ptr<SessionState>> m_sessions;
-        std::vector<lt::stats_metric> m_stats;
         std::vector<Timer> m_timers;
 
         SessionStatsSignal m_session_stats;


### PR DESCRIPTION
The `/metrics` endpoint now reports the `TYPE` and `HELP` (if any) for the provided metrics. These can help tools (and users) to better visualize data. A timestamp has also been added to show when the metrics were updated (in milliseconds since epoch).