### PR TITLE
feat(lua): add missing torrent workflow triggers

### DIFF
--- a/src/lua/packages/_/workflows.triggers.torrent.lua
+++ b/src/lua/packages/_/workflows.triggers.torrent.lua
@@ -32,6 +32,36 @@ return {
 
             table.insert(signals, signal)
         end
+    end,
+
+    paused = function()
+        return function(callback)
+            local signal = events.on("torrent_paused", function(torrent)
+                callback(torrent)
+            end)
+
+            table.insert(signals, signal)
+        end
+    end,
+
+    removed = function()
+        return function(callback)
+            local signal = events.on("torrent_removed", function(info_hash)
+                callback({ info_hash = info_hash })
+            end)
+
+            table.insert(signals, signal)
+        end
+    end,
+
+    resumed = function()
+        return function(callback)
+            local signal = events.on("torrent_resumed", function(torrent)
+                callback(torrent)
+            end)
+
+            table.insert(signals, signal)
+        end
     end
 }
 


### PR DESCRIPTION
This adds the following to the torrent workflow triggers,

 * `paused`
 * `removed`
 * `resumed`

Using `removed` is special since `ctx.torrent` is not a real torrent object by that point (since it has been removed). The only valid property on the torrent for that event is `info_hash`.