### PR TITLE
feat(lua): resolve body in http workflow action

### DIFF
--- a/src/lua/packages/_/workflows.actions.http.lua
+++ b/src/lua/packages/_/workflows.actions.http.lua
@@ -20,7 +20,7 @@ return function(args)
         end
 
         http.request({
-            body     = args.body,
+            body     = resolve(args.body, ctx),
             method   = resolve(args.method, ctx),
             url      = resolve(args.url, ctx),
             headers  = resolved_headers,


### PR DESCRIPTION
Allows you to resolve the value of the HTTP body, like so,

```lua
http({
    url = "https://ntfy.sh/porla-secret-topic",
    method = "POST",
    headers = {
        ["Title"] = "Nuovo torrent aggiunto",
        ["Icon"] = "https://porla.org/img/logo.svg",
        ["Tag"] = "loudspeaker,porla,new-download",
        ["Content-Type"] = "application/x-www-form-urlencoded"
    },
    body = function(ctx)
        return string.format("torrent added: %s", ctx.torrent.info_hash.v1)
    end
})
```