### PR TITLE
feat(lua)!: lua api now maps much more closely to the libtorrent api

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,6 +146,7 @@ add_library(
     src/lua/packages/json.cpp
     src/lua/packages/log.cpp
     src/lua/packages/pql.cpp
+    src/lua/packages/presets.cpp
     src/lua/packages/process.cpp
     src/lua/packages/sessions.cpp
     src/lua/packages/sqlite.cpp

--- a/src/http/eventshandler.cpp
+++ b/src/http/eventshandler.cpp
@@ -99,10 +99,10 @@ private:
         }).dump());
     }
 
-    void OnTorrentResumed(const std::string& session, const libtorrent::torrent_status& status)
+    void OnTorrentResumed(const std::string& session, const libtorrent::torrent_handle& th)
     {
         Broadcast("torrent_resumed", json({
-            {"info_hash", status.info_hashes},
+            {"info_hash", th.info_hashes()},
             {"session", session}
         }).dump());
     }

--- a/src/lua/packages/_/workflows.actions.torrent.lua
+++ b/src/lua/packages/_/workflows.actions.torrent.lua
@@ -53,17 +53,18 @@ return {
 
     remove = function(args)
         return function(ctx, callback)
-            local signal_connection = nil
+            local removing_info_hash = ctx.torrent:info_hash()
+            local signal_connection  = nil
 
             signal_connection = events.on("torrent_removed", function(info_hash)
-                if info_hash == ctx.torrent:info_hash() then
+                if info_hash == removing_info_hash then
                     signal_connection = nil
                     callback()
                 end
             end)
 
             for session in sessions.list() do
-                if session:find_torrent(ctx.torrent:info_hash()) do
+                if session:find_torrent(ctx.torrent:info_hash()) then
                     session:remove_torrent(ctx.torrent, args)
                 end
             end

--- a/src/lua/packages/_/workflows.actions.torrent.lua
+++ b/src/lua/packages/_/workflows.actions.torrent.lua
@@ -2,8 +2,8 @@ R"luastring"--(
 
 local events   = require "events"
 local log      = require "log"
+local sessions = require "sessions"
 local timers   = require "timers"
-local torrents = require "torrents"
 
 local function resolve(arg, ctx)
     if type(arg) == "function" then
@@ -19,15 +19,13 @@ return {
             local signal_connection = nil
 
             signal_connection = events.on("torrent_moved", function(torrent)
-                if torrent.info_hash == ctx.torrent.info_hash then
+                if torrent:info_hash() == ctx.torrent:info_hash() then
                     signal_connection = nil
                     callback()
                 end
             end)
 
-            torrents.move(ctx.torrent, {
-                path = resolve(args.path, ctx)
-            })
+            ctx.torrent:move_storage(resolve(args.path, ctx))
         end
     end,
 
@@ -35,7 +33,7 @@ return {
         return function(ctx, callback)
             -- if the torrent is already paused, do nothing, just continue the workflow
 
-            if ctx.torrent.is_paused then
+            if ctx.torrent:flags().paused then
                 callback()
                 return
             end
@@ -43,123 +41,13 @@ return {
             local signal_connection = nil
 
             signal_connection = events.on("torrent_paused", function(torrent)
-                if torrent.info_hash == ctx.torrent.info_hash then
+                if torrent:info_hash() == ctx.torrent:info_hash() then
                     signal_connection = nil
                     callback()
                 end
             end)
 
-            torrents.pause(ctx.torrent)
-        end
-    end,
-
-    reannounce = function(args)
-        return function(ctx, callback)
-            local current_tries    = 0
-            local interval         = 2
-            local max_tries        = 5
-            local tracker_index    = 0
-            local reannounce_timer = nil
-
-            if args and type(args.interval) == "number" then
-                interval = args.interval
-            end
-
-            if args and type(args.max_tries) == "number" then
-                max_tries = args.max_tries
-            end
-
-            if args and type(args.tracker_index) == "number" then
-                tracker_index = args.tracker_index
-            end
-
-            local peers = torrents.peers.list(ctx.torrent)
-
-            if #(peers) > 0 then
-                log.info(string.format("Torrent has %d peer(s) - skipping reannounce", #(peers)))
-                return callback()
-            end
-
-            reannounce_timer = timers.new({
-                interval = interval * 1000,
-                callback = function()
-                    local peers = torrents.peers.list(ctx.torrent)
-
-                    if #(peers) > 0 then
-                        log.info("Torrent now has peers - finishing")
-
-                        reannounce_timer:cancel()
-                        reannounce_timer = nil
-
-                        return callback()
-                    end
-
-                    current_tries = current_tries + 1
-
-                    if current_tries >= max_tries then
-                        log.warning(string.format("Max reannounce tries reached for %s", ctx.torrent.name))
-
-                        reannounce_timer:cancel()
-                        reannounce_timer = nil
-
-                        return callback()
-                    end
-
-                    local match_failures = {
-                        "not exist",
-                        "not found",
-                        "not registered",
-                        "unregistered",
-                        "not authorized"
-                    }
-
-                    local trackers = torrents.trackers.list(ctx.torrent)
-                    local found_matching_failure = false
-
-                    for _, tracker in ipairs(trackers) do
-                        for _, endpoint in ipairs(tracker.endpoints) do
-                            for _, aih in ipairs(endpoint.info_hashes) do
-                                for _, message in ipairs(match_failures) do
-                                    local i, j = string.find(aih.message, message)
-
-                                    if i == nil or j == nil then
-                                        goto next_message
-                                    end
-
-                                    found_matching_failure = true
-
-                                    ::next_message::
-                                end
-                            end
-                        end
-                    end
-
-                    if found_matching_failure then
-                        log.info(string.format("Sending reannounce attempt %d of %d for %s", current_tries + 1, max_tries, ctx.torrent.name))
-
-                        torrents.reannounce(ctx.torrent, {
-                            seconds       = 0,
-                            tracker_index = tracker_index
-                        })
-
-                        return
-                    end
-
-                    log.warning("No tracker matches any known failure - skipping reannounce")
-
-                    reannounce_timer:cancel()
-                    reannounce_timer = nil
-
-                    return callback()
-                end
-            })
-
-            log.info(string.format("Sending reannounce attempt %d of %d for %s", current_tries + 1, max_tries, ctx.torrent.name))
-
-            torrents.reannounce(ctx.torrent, {
-                seconds       = 0,
-                tracker_index = tracker_index
-            })
+            ctx.torrent:pause()
         end
     end,
 
@@ -168,13 +56,17 @@ return {
             local signal_connection = nil
 
             signal_connection = events.on("torrent_removed", function(info_hash)
-                if info_hash == ctx.torrent.info_hash then
+                if info_hash == ctx.torrent:info_hash() then
                     signal_connection = nil
                     callback()
                 end
             end)
 
-            torrents.remove(ctx.torrent, args)
+            for session in sessions.list() do
+                if session:find_torrent(ctx.torrent:info_hash()) do
+                    session:remove_torrent(ctx.torrent, args)
+                end
+            end
         end
     end,
 
@@ -182,7 +74,7 @@ return {
         return function(ctx, callback)
             -- if the torrent is already resumed, do nothing, just continue the workflow
 
-            if not ctx.torrent.is_paused then
+            if not ctx.torrent:flags().paused then
                 callback()
                 return
             end
@@ -190,13 +82,13 @@ return {
             local signal_connection = nil
 
             signal_connection = events.on("torrent_resumed", function(torrent)
-                if torrent.info_hash == ctx.torrent.info_hash then
+                if torrent:info_hash() == ctx.torrent:info_hash() then
                     signal_connection = nil
                     callback()
                 end
             end)
 
-            torrents.resume(ctx.torrent)
+            ctx.torrent:resume()
         end
     end
 }

--- a/src/lua/packages/_/workflows.lua
+++ b/src/lua/packages/_/workflows.lua
@@ -56,8 +56,8 @@ local function add(workflow)
 
         if type(workflow.filter) == "function" then
             should_execute = workflow.filter(ctx)
-        elseif type(workflow.filter) == "string" then
-            should_execute = pql_filter:includes(torrent)
+        elseif type(workflow.filter) == "string" and type(torrent.status) == "function" then
+            should_execute = pql_filter:includes(torrent:status())
         end
 
         if not should_execute then

--- a/src/lua/packages/_/workflows.triggers.cron.lua
+++ b/src/lua/packages/_/workflows.triggers.cron.lua
@@ -1,6 +1,6 @@
 R"luastring"--(
 local cron     = require "cron"
-local torrents = require "torrents"
+local sessions = require "sessions"
 
 local signals = {}
 
@@ -9,8 +9,10 @@ return function(expression)
         local signal = cron.schedule({
             expression = expression,
             callback   = function()
-                for _, torrent in pairs(torrents.list()) do
-                    callback(torrent)
+                for session in sessions.list() do
+                    for torrent in session:torrents() do
+                        callback(torrent)
+                    end
                 end
             end
         })

--- a/src/lua/packages/_/workflows.triggers.interval.lua
+++ b/src/lua/packages/_/workflows.triggers.interval.lua
@@ -1,6 +1,6 @@
 R"luastring"--(
+local sessions = require "sessions"
 local timers   = require "timers"
-local torrents = require "torrents"
 
 local signals = {}
 
@@ -9,8 +9,10 @@ return function(interval)
         local signal = timers.new({
             interval = interval,
             callback = function()
-                for _, torrent in pairs(torrents.list()) do
-                    callback(torrent)
+                for session in sessions.list() do
+                    for torrent in session:torrents() do
+                        callback(torrent)
+                    end
                 end
             end
         })

--- a/src/lua/packages/events.cpp
+++ b/src/lua/packages/events.cpp
@@ -89,7 +89,7 @@ void Events::Register(sol::state& lua)
                     {
                         try
                         {
-                            cb(th.status());
+                            cb(th);
                         }
                         catch (const sol::error& err)
                         {
@@ -107,7 +107,7 @@ void Events::Register(sol::state& lua)
                     {
                         try
                         {
-                            cb(th.status());
+                            cb(th);
                         }
                         catch (const sol::error& err)
                         {

--- a/src/lua/packages/events.cpp
+++ b/src/lua/packages/events.cpp
@@ -49,11 +49,11 @@ void Events::Register(sol::state& lua)
             if (name == "torrent_added")
             {
                 auto connection = options.sessions.OnTorrentAdded(
-                    [cb = callback](const std::string& session, const lt::torrent_status& ts)
+                    [cb = callback](const std::string& session, const lt::torrent_handle& th)
                     {
                         try
                         {
-                            cb(ts);
+                            cb(th);
                         }
                         catch (const sol::error& err)
                         {
@@ -67,11 +67,11 @@ void Events::Register(sol::state& lua)
             if (name == "torrent_finished")
             {
                 auto connection = options.sessions.OnTorrentFinished(
-                    [cb = callback](const std::string& session, const lt::torrent_status& ts)
+                    [cb = callback](const std::string& session, const lt::torrent_handle& th)
                     {
                         try
                         {
-                            cb(ts);
+                            cb(th);
                         }
                         catch (const sol::error& err)
                         {
@@ -139,11 +139,11 @@ void Events::Register(sol::state& lua)
             if (name == "torrent_resumed")
             {
                 auto connection = options.sessions.OnTorrentResumed(
-                    [cb = callback](const std::string& session, const lt::torrent_status& ts)
+                    [cb = callback](const std::string& session, const lt::torrent_handle& th)
                     {
                         try
                         {
-                            cb(ts);
+                            cb(th);
                         }
                         catch (const sol::error& err)
                         {

--- a/src/lua/packages/presets.cpp
+++ b/src/lua/packages/presets.cpp
@@ -1,0 +1,42 @@
+#include "presets.hpp"
+
+#include "../../config.hpp"
+#include "../plugins/plugin.hpp"
+
+using porla::Lua::Packages::Presets;
+
+void Presets::Register(sol::state& lua)
+{
+    auto preset_type = lua.new_usertype<Config::Preset>(
+        "porla.Preset",
+        sol::no_constructor,
+        "category",        sol::readonly(&Config::Preset::category),
+        "download_limit",  sol::readonly(&Config::Preset::download_limit),
+        "max_connections", sol::readonly(&Config::Preset::max_connections),
+        "max_uploads",     sol::readonly(&Config::Preset::max_uploads),
+        "save_path",       sol::readonly(&Config::Preset::save_path),
+        "session",         sol::readonly(&Config::Preset::session),
+        "tags",            sol::readonly(&Config::Preset::tags),
+        "upload_limit",    sol::readonly(&Config::Preset::upload_limit));
+
+    lua["package"]["preload"]["presets"] = [](sol::this_state s)
+    {
+        sol::state_view lua{s};
+        sol::table presets = lua.create_table();
+
+        presets["get"] = [](sol::this_state s, const std::string& name) -> std::optional<Config::Preset>
+        {
+            sol::state_view lua{s};
+            const auto options = lua.globals()["__load_opts"].get<const Plugins::PluginLoadOptions&>();
+
+            if (options.config.presets.find(name) == options.config.presets.end())
+            {
+                return std::nullopt;
+            }
+
+            return options.config.presets.at(name);
+        };
+
+        return presets;
+    };
+}

--- a/src/lua/packages/presets.hpp
+++ b/src/lua/packages/presets.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <sol/sol.hpp>
+
+namespace porla::Lua::Packages
+{
+    class Presets
+    {
+    public:
+        static void Register(sol::state& lua);
+    };
+}

--- a/src/lua/packages/sessions.cpp
+++ b/src/lua/packages/sessions.cpp
@@ -100,10 +100,86 @@ void Sessions::Register(sol::state& lua)
         "upload_limit",    &lt::add_torrent_params::upload_limit,
         "userdata",        sol::property([](const lt::add_torrent_params& p) { return p.userdata.get<TorrentClientData>(); }));
 
+    auto settings_pack_type = lua.new_usertype<lt::settings_pack>(
+        "SettingsPack",
+        // the lt settings packs
+        "default",                     sol::factories([]() { return lt::default_settings(); }),
+        "high_performance_seed",       sol::factories([]() { return lt::high_performance_seed(); }),
+        "min_memory_usage",            sol::factories([]() { return lt::min_memory_usage(); }),
+        // get & set
+        sol::meta_function::index,     [](lt::settings_pack& sp, sol::stack_object key, sol::this_state L)
+        {
+            const auto key_str = key.as<std::optional<std::string>>();
+
+            if (!key_str.has_value())
+            {
+                return sol::object(L, sol::in_place, sol::lua_nil);
+            }
+
+            const int type = lt::setting_by_name(key_str.value());
+
+            if (type == -1)
+            {
+                BOOST_LOG_TRIVIAL(warning) << "Unknown setting: " << key_str.value();
+                return sol::object(L, sol::in_place, sol::lua_nil);
+            }
+
+            if ((type & lt::settings_pack::type_mask) == lt::settings_pack::bool_type_base)
+            {
+                return sol::object(L, sol::in_place, sp.get_bool(type));
+            }
+
+            if ((type & lt::settings_pack::type_mask) == lt::settings_pack::int_type_base)
+            {
+                return sol::object(L, sol::in_place, sp.get_int(type));
+            }
+
+            if ((type & lt::settings_pack::type_mask) == lt::settings_pack::string_type_base)
+            {
+                return sol::object(L, sol::in_place, sp.get_str(type));
+            }
+
+            return sol::object(L, sol::in_place, sol::lua_nil);
+        },
+        sol::meta_function::new_index, [](lt::settings_pack& sp, sol::stack_object key, sol::stack_object value)
+        {
+            const auto key_str = key.as<std::optional<std::string>>();
+
+            if (!key_str.has_value() || porla::Sessions::DisallowedSetting(key_str.value()))
+            {
+                return;
+            }
+
+            const int type = lt::setting_by_name(key_str.value());
+
+            if (type == -1)
+            {
+                BOOST_LOG_TRIVIAL(warning) << "Unknown setting: " << key_str.value();
+                return;
+            }
+
+            if ((type & lt::settings_pack::type_mask) == lt::settings_pack::bool_type_base && value.is<bool>())
+            {
+                sp.set_bool(type, value.as<bool>());
+            }
+
+            if ((type & lt::settings_pack::type_mask) == lt::settings_pack::int_type_base && value.is<int>())
+            {
+                sp.set_int(type, value.as<int>());
+            }
+
+            if ((type & lt::settings_pack::type_mask) == lt::settings_pack::string_type_base && value.is<std::string>())
+            {
+                sp.set_str(type, value.as<std::string>());
+            }
+        });
+
     auto session_type = lua.new_usertype<porla::Sessions::SessionState>(
         "porla.Session",
         sol::no_constructor,
-        "name", sol::readonly(&porla::Sessions::SessionState::name));
+        "apply_settings", [](const porla::Sessions::SessionState& state, const lt::settings_pack& sp) { state.session->apply_settings(sp); },
+        "name",           sol::readonly(&porla::Sessions::SessionState::name),
+        "settings",       [](const porla::Sessions::SessionState& state) { return state.session->get_settings(); });
 
     session_type["add_torrent"] = [](const std::shared_ptr<porla::Sessions::SessionState>& state, lt::add_torrent_params& params)
     {
@@ -157,114 +233,6 @@ void Sessions::Register(sol::state& lua)
             sol::state_view lua{s};
             const auto options = lua.globals()["__load_opts"].get<const Plugins::PluginLoadOptions&>();
             return SessionsIter(options.sessions.All().begin());
-        };
-
-        sessions["settings"] = lua.create_table();
-        sessions["settings"]["get"] = [](sol::this_state s, const std::string& session) -> sol::reference
-        {
-            sol::state_view lua{s};
-            const auto options = lua.globals()["__load_opts"].get<const Plugins::PluginLoadOptions&>();
-            const auto state = options.sessions.Get(session);
-
-            if (state == nullptr)
-            {
-                BOOST_LOG_TRIVIAL(warning) << "Could not find session " << session;
-                return sol::nil;
-            }
-
-            const auto& session_settings = state->session->get_settings();
-
-            sol::table settings = lua.create_table();
-
-            for (int i = lt::settings_pack::bool_type_base; i < lt::settings_pack::max_bool_setting_internal; i++)
-            {
-                const char *name = lt::name_for_setting(i);
-                if (strcmp(name, "") == 0) continue;
-                settings[name] = session_settings.get_bool(i);
-            }
-
-            for (int i = lt::settings_pack::int_type_base; i < lt::settings_pack::max_int_setting_internal; i++)
-            {
-                const char *name = lt::name_for_setting(i);
-                if (strcmp(name, "") == 0) continue;
-                settings[name] = session_settings.get_int(i);
-            }
-
-            for (int i = lt::settings_pack::string_type_base; i < lt::settings_pack::max_string_setting_internal; i++)
-            {
-                const char *name = lt::name_for_setting(i);
-                if (strcmp(name, "") == 0) continue;
-                settings[name] = session_settings.get_str(i);
-            }
-
-            return settings;
-        };
-
-        sessions["settings"]["set"] = [](sol::this_state s, const std::string& session, const sol::table& settings)
-        {
-            sol::state_view lua{s};
-            const auto options = lua.globals()["__load_opts"].get<const Plugins::PluginLoadOptions&>();
-            const auto state = options.sessions.Get(session);
-
-            if (state == nullptr)
-            {
-                BOOST_LOG_TRIVIAL(warning) << "Could not find session " << session;
-                return;
-            }
-
-            lt::settings_pack session_settings = state->session->get_settings();
-
-            for (const auto& [ key, value ] : settings)
-            {
-                const auto key_str = key.as<std::string>();
-
-                if (porla::Sessions::DisallowedSetting(key_str))
-                {
-                    BOOST_LOG_TRIVIAL(warning) << "Will not set setting " << key_str;
-                    continue;
-                }
-
-                const int type = lt::setting_by_name(key_str);
-
-                if (type == -1)
-                {
-                    BOOST_LOG_TRIVIAL(warning) << "Unknown setting: " << key_str;
-                    continue;
-                }
-
-                if ((type & lt::settings_pack::type_mask) == lt::settings_pack::bool_type_base)
-                {
-                    if (!value.is<bool>())
-                    {
-                        BOOST_LOG_TRIVIAL(warning) << "Value for setting " << key_str << " is not a boolean";
-                        continue;
-                    }
-
-                    session_settings.set_bool(type, value.as<bool>());
-                }
-                else if((type & lt::settings_pack::type_mask) == lt::settings_pack::int_type_base)
-                {
-                    if (!value.is<int>())
-                    {
-                        BOOST_LOG_TRIVIAL(warning) << "Value for setting " << key_str << " is not an integer";
-                        continue;
-                    }
-
-                    session_settings.set_int(type, value.as<int>());
-                }
-                else if((type & lt::settings_pack::type_mask) == lt::settings_pack::string_type_base)
-                {
-                    if (!value.is<std::string>())
-                    {
-                        BOOST_LOG_TRIVIAL(warning) << "Value for setting " << key_str << " is not a string";
-                        continue;
-                    }
-
-                    session_settings.set_str(type, value.as<std::string>());
-                }
-            }
-
-            state->session->apply_settings(session_settings);
         };
 
         return sessions;

--- a/src/lua/packages/sessions.cpp
+++ b/src/lua/packages/sessions.cpp
@@ -4,16 +4,136 @@
 
 #include "../plugins/plugin.hpp"
 #include "../../sessions.hpp"
+#include "../../torrentclientdata.hpp"
 
 using porla::Lua::Packages::Sessions;
 using porla::Lua::Plugins::PluginLoadOptions;
+using porla::TorrentClientData;
+
+class SessionsIter
+{
+public:
+    explicit SessionsIter(std::map<std::string, std::shared_ptr<porla::Sessions::SessionState>>::const_iterator begin)
+        : m_iter(begin)
+    {
+    }
+
+    std::shared_ptr<porla::Sessions::SessionState> operator()(sol::this_state s)
+    {
+        sol::state_view lua{s};
+        const auto options = lua.globals()["__load_opts"].get<const porla::Lua::Plugins::PluginLoadOptions&>();
+
+        if (m_iter == options.sessions.All().end()) return nullptr;
+
+        auto session = m_iter->second;
+        std::advance(m_iter, 1);
+        return session;
+    }
+
+private:
+    std::map<std::string, std::shared_ptr<porla::Sessions::SessionState>>::const_iterator m_iter;
+};
+
+class TorrentsIter
+{
+public:
+    explicit TorrentsIter(const porla::Sessions::SessionState& state)
+        : m_state(state)
+        , m_iter(state.torrents.begin())
+    {
+    }
+
+    std::optional<lt::torrent_handle> operator()()
+    {
+        if (m_iter == m_state.torrents.end()) return std::nullopt;
+
+        auto th = m_iter->second;
+        std::advance(m_iter, 1);
+        return th;
+    }
+
+private:
+    const porla::Sessions::SessionState& m_state;
+    std::map<lt::info_hash_t, lt::torrent_handle>::const_iterator m_iter;
+};
 
 void Sessions::Register(sol::state& lua)
 {
+    auto atp_type = lua.new_usertype<lt::add_torrent_params>(
+        "AddTorrentParams",
+        "download_limit",  &lt::add_torrent_params::download_limit,
+        "file_priorities", &lt::add_torrent_params::file_priorities,
+        // flags,
+        "info_hash",       &lt::add_torrent_params::info_hashes,
+        "max_connections", &lt::add_torrent_params::max_connections,
+        "max_uploads",     &lt::add_torrent_params::max_uploads,
+        "name",            &lt::add_torrent_params::name,
+        "save_path",       &lt::add_torrent_params::save_path,
+        // storage mode
+        "ti",              &lt::add_torrent_params::ti,
+        "tracker_tiers",   &lt::add_torrent_params::tracker_tiers,
+        "trackerid",       &lt::add_torrent_params::trackerid,
+        "trackers",        &lt::add_torrent_params::trackers,
+        "upload_limit",    &lt::add_torrent_params::upload_limit);
+
+    auto session_type = lua.new_usertype<porla::Sessions::SessionState>(
+        "porla.Session",
+        sol::no_constructor,
+        "name", sol::readonly(&porla::Sessions::SessionState::name));
+
+    session_type["add_torrent"] = [](const std::shared_ptr<porla::Sessions::SessionState>& state, lt::add_torrent_params& params)
+    {
+        params.userdata = lt::client_data_t(new TorrentClientData());
+        params.userdata.get<TorrentClientData>()->state = state;
+
+        // TODO: set category and tags
+
+        state->session->async_add_torrent(params);
+    };
+
+    session_type["find_torrent"] = [](const std::shared_ptr<porla::Sessions::SessionState>& state, const lt::info_hash_t& ih) -> std::optional<lt::torrent_handle>
+    {
+        const auto it = state->torrents.find(ih);
+
+        if (it == state->torrents.end())
+        {
+            return std::nullopt;
+        }
+
+        return it->second;
+    };
+
+    session_type["remove_torrent"] = [](const porla::Sessions::SessionState& state, const lt::torrent_handle& th, const sol::table& args)
+    {
+        bool remove_files = false;
+        if (args["remove_files"].valid()) { remove_files = args["remove_files"].get<bool>(); }
+
+        state.session->remove_torrent(th, remove_files ? lt::session::delete_files : lt::remove_flags_t{});
+    };
+
+    session_type["torrents"] = [](const porla::Sessions::SessionState& state)
+    {
+        return TorrentsIter(state);
+    };
+
     lua["package"]["preload"]["sessions"] = [](sol::this_state s)
     {
         sol::state_view lua{s};
         sol::table sessions = lua.create_table();
+
+        sessions["get"] = [](sol::this_state s, const std::string& name)
+        {
+            sol::state_view lua{s};
+            const auto options = lua.globals()["__load_opts"].get<const Plugins::PluginLoadOptions&>();
+            return options.sessions.Get(name);
+        };
+
+        sessions["list"] = [](sol::this_state s)
+        {
+            sol::state_view lua{s};
+            const auto options = lua.globals()["__load_opts"].get<const Plugins::PluginLoadOptions&>();
+            return SessionsIter(options.sessions.All().begin());
+        };
 
         sessions["settings"] = lua.create_table();
         sessions["settings"]["get"] = [](sol::this_state s, const std::string& session) -> sol::reference

--- a/src/lua/packages/sessions.cpp
+++ b/src/lua/packages/sessions.cpp
@@ -183,11 +183,7 @@ void Sessions::Register(sol::state& lua)
 
     session_type["add_torrent"] = [](const std::shared_ptr<porla::Sessions::SessionState>& state, lt::add_torrent_params& params)
     {
-        params.userdata = lt::client_data_t(new TorrentClientData());
         params.userdata.get<TorrentClientData>()->state = state;
-
-        // TODO: set category and tags
-
         state->session->async_add_torrent(params);
     };
 

--- a/src/lua/packages/torrents.cpp
+++ b/src/lua/packages/torrents.cpp
@@ -31,6 +31,81 @@ static void ApplyPreset(lt::add_torrent_params& p, const porla::Config::Preset& 
         p.userdata.get<porla::TorrentClientData>()->tags = preset.tags;
 }
 
+static std::map<std::string, bool> FlagsToMap(const lt::torrent_flags_t& flags)
+{
+#define SET_INSERT_FLAG(name) \
+    if ((flags & lt::torrent_flags:: name) == lt::torrent_flags:: name) \
+    { \
+        result_flags.insert({#name, true}); \
+    } \
+    else \
+    { \
+        result_flags.insert({#name, false}); \
+    } \
+
+    std::map<std::string, bool> result_flags;
+    SET_INSERT_FLAG(seed_mode)
+    SET_INSERT_FLAG(upload_mode)
+    SET_INSERT_FLAG(share_mode)
+    SET_INSERT_FLAG(apply_ip_filter)
+    SET_INSERT_FLAG(paused)
+    SET_INSERT_FLAG(auto_managed)
+    SET_INSERT_FLAG(duplicate_is_error)
+    SET_INSERT_FLAG(update_subscribe)
+    SET_INSERT_FLAG(super_seeding)
+    SET_INSERT_FLAG(sequential_download)
+    SET_INSERT_FLAG(stop_when_ready)
+    SET_INSERT_FLAG(override_trackers)
+    SET_INSERT_FLAG(override_web_seeds)
+    SET_INSERT_FLAG(need_save_resume)
+    SET_INSERT_FLAG(disable_dht)
+    SET_INSERT_FLAG(disable_lsd)
+    SET_INSERT_FLAG(disable_pex)
+    SET_INSERT_FLAG(no_verify_files)
+    SET_INSERT_FLAG(default_dont_download)
+    SET_INSERT_FLAG(i2p_torrent)
+    return result_flags;
+}
+
+static void SetHandleFlags(const lt::torrent_handle& th, const sol::table& flags_tbl)
+{
+    lt::torrent_flags_t flags;
+    lt::torrent_flags_t mask;
+
+#define SET_FLAG(name) \
+    if (flags_tbl[#name].valid()) \
+    { \
+        mask |= lt::torrent_flags:: name; \
+        if (flags_tbl[#name].get<bool>()) \
+        { \
+            flags |= lt::torrent_flags:: name; \
+        } \
+    }
+
+    SET_FLAG(seed_mode)
+    SET_FLAG(upload_mode)
+    SET_FLAG(share_mode)
+    SET_FLAG(apply_ip_filter)
+    SET_FLAG(paused)
+    SET_FLAG(auto_managed)
+    SET_FLAG(duplicate_is_error)
+    SET_FLAG(update_subscribe)
+    SET_FLAG(super_seeding)
+    SET_FLAG(sequential_download)
+    SET_FLAG(stop_when_ready)
+    SET_FLAG(override_trackers)
+    SET_FLAG(override_web_seeds)
+    SET_FLAG(need_save_resume)
+    SET_FLAG(disable_dht)
+    SET_FLAG(disable_lsd)
+    SET_FLAG(disable_pex)
+    SET_FLAG(no_verify_files)
+    SET_FLAG(default_dont_download)
+    SET_FLAG(i2p_torrent)
+
+    th.set_flags(flags, mask);
+}
+
 void Torrents::Register(sol::state& lua)
 {
     auto announce_infohash_type = lua.new_usertype<lt::announce_infohash>(
@@ -135,6 +210,10 @@ void Torrents::Register(sol::state& lua)
         "clear_error",             &lt::torrent_handle::clear_error,
         "clear_peers",             &lt::torrent_handle::clear_peers,
         "download_limit",          &lt::torrent_handle::download_limit,
+        "flags",                   [](const lt::torrent_handle& th)
+                                   {
+                                       return FlagsToMap(th.flags());
+                                   },
         "flush_cache",             &lt::torrent_handle::flush_cache,
         "force_reannounce",        [](const lt::torrent_handle& th, const sol::table& args)
                                    {
@@ -159,6 +238,8 @@ void Torrents::Register(sol::state& lua)
                                        th.get_peer_info(peers);
                                        return peers;
                                    },
+        "post_download_queue",     &lt::torrent_handle::post_download_queue,
+        "post_file_progress",      [](const lt::torrent_handle& th) { return th.post_file_progress(lt::torrent_handle::piece_granularity); },
         "post_peer_info",          &lt::torrent_handle::post_peer_info,
         "post_piece_availability", &lt::torrent_handle::post_piece_availability,
         "post_status",             [](const lt::torrent_handle& th) { return th.post_status(); },
@@ -170,6 +251,7 @@ void Torrents::Register(sol::state& lua)
         "queue_position_up",       &lt::torrent_handle::queue_position_up,
         "resume",                  &lt::torrent_handle::resume,
         "set_download_limit",      &lt::torrent_handle::set_download_limit,
+        "set_flags",               [](const lt::torrent_handle& th, const sol::table& flags) { SetHandleFlags(th, flags); },
         "set_max_connections",     &lt::torrent_handle::set_max_connections,
         "set_max_uploads",         &lt::torrent_handle::set_max_uploads,
         "set_upload_limit",        &lt::torrent_handle::set_upload_limit,
@@ -200,7 +282,7 @@ void Torrents::Register(sol::state& lua)
         // errc
         // error_file
         // finished duration
-        // flags
+        "flags",                  sol::property([](const lt::torrent_status& ts) { return FlagsToMap(ts.flags); }),
         "info_hash",              sol::readonly(&lt::torrent_status::info_hashes),
         "is_finished",            sol::readonly(&lt::torrent_status::is_finished),
         "is_seeding",             sol::readonly(&lt::torrent_status::is_seeding),
@@ -247,133 +329,10 @@ void Torrents::Register(sol::state& lua)
         // verified pieces
         );
 
-    torrent_status_type["category"] = sol::property(
-        [](const lt::torrent_status& ts)
-        {
-            const TorrentClientData* client_data = ts.handle.userdata().get<TorrentClientData>();
-            return client_data->category;
-        });
-
-    torrent_status_type["flags"] = sol::property(
-        [](const lt::torrent_status& ts)
-        {
-#define SET_INSERT_FLAG(name) if ((ts.flags & lt::torrent_flags:: name) == lt::torrent_flags:: name) flags.insert(#name);
-
-            std::set<std::string> flags;
-            SET_INSERT_FLAG(seed_mode)
-            SET_INSERT_FLAG(upload_mode)
-            SET_INSERT_FLAG(share_mode)
-            SET_INSERT_FLAG(apply_ip_filter)
-            SET_INSERT_FLAG(paused)
-            SET_INSERT_FLAG(auto_managed)
-            SET_INSERT_FLAG(duplicate_is_error)
-            SET_INSERT_FLAG(update_subscribe)
-            SET_INSERT_FLAG(super_seeding)
-            SET_INSERT_FLAG(sequential_download)
-            SET_INSERT_FLAG(stop_when_ready)
-            SET_INSERT_FLAG(override_trackers)
-            SET_INSERT_FLAG(override_web_seeds)
-            SET_INSERT_FLAG(need_save_resume)
-            SET_INSERT_FLAG(disable_dht)
-            SET_INSERT_FLAG(disable_lsd)
-            SET_INSERT_FLAG(disable_pex)
-            SET_INSERT_FLAG(no_verify_files)
-            SET_INSERT_FLAG(default_dont_download)
-            SET_INSERT_FLAG(i2p_torrent)
-
-            return flags;
-        });
-
     lua["package"]["preload"]["torrents"] = [](sol::this_state s)
     {
         sol::state_view lua{s};
         sol::table torrents = lua.create_table();
-
-        torrents["add"] = [](sol::this_state s, const sol::table& args)
-        {
-            sol::state_view lua{s};
-            const auto options = lua.globals()["__load_opts"].get<const Plugins::PluginLoadOptions&>();
-
-            const auto& state = args["preset"].is<std::string>()
-                ? options.config.presets.find(args["preset"]) != options.config.presets.end()
-                  ? options.config.presets.at(args["preset"]).session.has_value()
-                    ? options.sessions.Get(options.config.presets.at(args["preset"]).session.value())
-                    : options.sessions.Default()
-                  : options.sessions.Default()
-                : options.config.presets.find("default") != options.config.presets.end()
-                  ? options.config.presets.at("default").session.has_value()
-                    ? options.sessions.Get(options.config.presets.at("default").session.value())
-                    : options.sessions.Default()
-                  : options.sessions.Default();
-
-            lt::add_torrent_params p;
-            p.userdata = lt::client_data_t(new TorrentClientData());
-            p.userdata.get<TorrentClientData>()->state = state;
-
-            // Apply the 'default' preset if it exists
-            if (options.config.presets.find("default") != options.config.presets.end())
-            {
-                ApplyPreset(p, options.config.presets.at("default"));
-            }
-
-            if (args["preset"].is<std::string>())
-            {
-                const auto preset_name = args["preset"].get<std::string>();
-                const auto preset = options.config.presets.find(preset_name);
-
-                if (preset == options.config.presets.end())
-                {
-                    BOOST_LOG_TRIVIAL(warning) << "Specified preset '" << preset_name << "' not found.";
-                }
-                // Only apply presets other than default here, since default is applied above..
-                else if (preset_name != "default")
-                {
-                    BOOST_LOG_TRIVIAL(debug) << "Applying preset " << preset_name;
-                    ApplyPreset(p, preset->second);
-                }
-            }
-
-            if (args["ti"].is<std::shared_ptr<lt::torrent_info>>())
-            {
-                p.ti = args["ti"].get<std::shared_ptr<lt::torrent_info>>();
-
-                for (const auto& [ name, s ]: options.sessions.All())
-                {
-                    if (s->torrents.find(p.ti->info_hashes()) != s->torrents.end())
-                    {
-                        BOOST_LOG_TRIVIAL(error) << "Torrent already in session";
-                        return;
-                    }
-                }
-            }
-            else if (args["magnet_uri"].is<std::string>())
-            {
-                lt::error_code ec;
-                lt::parse_magnet_uri(args["magnet_uri"].get<std::string>(), p, ec);
-
-                if (ec)
-                {
-                    BOOST_LOG_TRIVIAL(error) << "Failed to parse magnet uri: " << ec.message();
-                    return;
-                }
-            }
-
-            if (args["download_limit"].valid())  p.download_limit  = args["download_limit"].get<int>();
-            if (args["http_seeds"].valid())      p.http_seeds      = args["http_seeds"].get<std::vector<std::string>>();
-            if (args["max_connections"].valid()) p.max_connections = args["max_connections"].get<int>();
-            if (args["max_uploads"].valid())     p.max_uploads     = args["max_uploads"].get<int>();
-            if (args["name"].valid())            p.name            = args["name"].get<std::string>();
-            if (args["save_path"].valid())       p.save_path       = args["save_path"].get<std::string>();
-            if (args["trackers"].valid())        p.trackers        = args["trackers"].get<std::vector<std::string>>();
-            if (args["upload_limit"].valid())    p.upload_limit    = args["upload_limit"].get<int>();
-            if (args["url_seeds"].valid())       p.url_seeds       = args["url_seeds"].get<std::vector<std::string>>();
-
-            // userdata values
-            if (args["category"].valid())        p.userdata.get<TorrentClientData>()->category = args["category"].get<std::string>();
-            if (args["tags"].valid())            p.userdata.get<TorrentClientData>()->tags     = args["tags"].get<std::unordered_set<std::string>>();
-
-            state->session->async_add_torrent(p);
-        };
 
         torrents["errors"] = lua.create_table();
         torrents["errors"]["tracker_failure"] = lt::errors::tracker_failure;
@@ -391,95 +350,6 @@ void Torrents::Register(sol::state& lua)
             }
 
             return std::make_shared<lt::torrent_info>(data);
-        };
-
-        torrents["properties"] = lua.create_table();
-        torrents["properties"]["get"] = [](sol::this_state s, const lt::torrent_status& ts) -> sol::reference
-        {
-            if (!ts.handle.is_valid())
-            {
-                return sol::nil;
-            }
-
-            sol::state_view lua{s};
-            sol::table p = lua.create_table();
-
-#define INSERT_FLAG(name) flags.insert({ #name, (ts.flags & lt::torrent_flags:: name) == lt::torrent_flags:: name });
-
-            std::map<std::string, bool> flags;
-            INSERT_FLAG(seed_mode)
-            INSERT_FLAG(upload_mode)
-            INSERT_FLAG(share_mode)
-            INSERT_FLAG(apply_ip_filter)
-            INSERT_FLAG(paused)
-            INSERT_FLAG(auto_managed)
-            INSERT_FLAG(duplicate_is_error)
-            INSERT_FLAG(update_subscribe)
-            INSERT_FLAG(super_seeding)
-            INSERT_FLAG(sequential_download)
-            INSERT_FLAG(stop_when_ready)
-            INSERT_FLAG(override_trackers)
-            INSERT_FLAG(override_web_seeds)
-            INSERT_FLAG(need_save_resume)
-            INSERT_FLAG(disable_dht)
-            INSERT_FLAG(disable_lsd)
-            INSERT_FLAG(disable_pex)
-            INSERT_FLAG(no_verify_files)
-            INSERT_FLAG(default_dont_download)
-            INSERT_FLAG(i2p_torrent)
-
-            p["flags"]           = flags;
-
-            return p;
-        };
-
-        torrents["properties"]["set"] = [](sol::this_state s, const lt::torrent_status& ts, const sol::table& args)
-        {
-            if (!ts.handle.is_valid())
-            {
-                return;
-            }
-
-            lt::torrent_flags_t flags;
-            lt::torrent_flags_t mask;
-
-            if (args["flags"].valid())
-            {
-                const auto& flags_tbl = args["flags"].get<sol::table>();
-
-#define SET_FLAG(name) \
-    if (flags_tbl[#name].valid()) \
-    { \
-        mask |= lt::torrent_flags:: name; \
-        if (flags_tbl[#name].get<bool>()) \
-        { \
-            flags |= lt::torrent_flags:: name; \
-        } \
-    }
-
-                SET_FLAG(seed_mode)
-                SET_FLAG(upload_mode)
-                SET_FLAG(share_mode)
-                SET_FLAG(apply_ip_filter)
-                SET_FLAG(paused)
-                SET_FLAG(auto_managed)
-                SET_FLAG(duplicate_is_error)
-                SET_FLAG(update_subscribe)
-                SET_FLAG(super_seeding)
-                SET_FLAG(sequential_download)
-                SET_FLAG(stop_when_ready)
-                SET_FLAG(override_trackers)
-                SET_FLAG(override_web_seeds)
-                SET_FLAG(need_save_resume)
-                SET_FLAG(disable_dht)
-                SET_FLAG(disable_lsd)
-                SET_FLAG(disable_pex)
-                SET_FLAG(no_verify_files)
-                SET_FLAG(default_dont_download)
-                SET_FLAG(i2p_torrent)
-
-                ts.handle.set_flags(flags, mask);
-            }
         };
 
         return torrents;

--- a/src/lua/packages/torrents.cpp
+++ b/src/lua/packages/torrents.cpp
@@ -189,6 +189,15 @@ void Torrents::Register(sol::state& lua)
         "porla.TorrentClientData",
         sol::no_constructor,
         "category", &TorrentClientData::category,
+        "session",  sol::property([](const TorrentClientData& cd) -> std::optional<std::string>
+                    {
+                        if (auto s = cd.state.lock())
+                        {
+                            return s->name;
+                        }
+
+                        return std::nullopt;
+                    }),
         "tags",     &TorrentClientData::tags);
 
     auto torrent_info_type = lua.new_usertype<lt::torrent_info>(

--- a/src/lua/packages/torrents.cpp
+++ b/src/lua/packages/torrents.cpp
@@ -257,6 +257,7 @@ void Torrents::Register(sol::state& lua)
         "set_upload_limit",        &lt::torrent_handle::set_upload_limit,
         "status",                  [](const lt::torrent_handle& th) { return th.status(); },
         "trackers",                &lt::torrent_handle::trackers,
+        "torrent_file",            &lt::torrent_handle::torrent_file,
         "upload_limit",            &lt::torrent_handle::upload_limit,
         "userdata",                [](const lt::torrent_handle& th) { return th.userdata().get<TorrentClientData>(); });
 

--- a/src/lua/packages/torrents.cpp
+++ b/src/lua/packages/torrents.cpp
@@ -51,10 +51,10 @@ void Torrents::Register(sol::state& lua)
 
     auto announce_endpoint_type = lua.new_usertype<lt::announce_endpoint>(
         "lt.AnnounceEndpoint",
-        sol::no_constructor);
+        sol::no_constructor,
+        "enabled", sol::readonly(&lt::announce_endpoint::enabled),
+        "info_hashes", sol::readonly(&lt::announce_endpoint::info_hashes));
 
-    announce_endpoint_type["enabled"] = sol::property([](const lt::announce_endpoint& ae) { return ae.enabled; });
-    announce_endpoint_type["info_hashes"] = sol::property([](const lt::announce_endpoint& ae) { return ae.info_hashes; });
     announce_endpoint_type["local_endpoint"] = [](const lt::announce_endpoint& ae)
     {
         return std::make_tuple(
@@ -64,14 +64,14 @@ void Torrents::Register(sol::state& lua)
 
     auto announce_entry_type = lua.new_usertype<lt::announce_entry>(
         "lt.AnnounceEntry",
-        sol::no_constructor);
+        sol::no_constructor,
+        "endpoints",  sol::readonly(&lt::announce_entry::endpoints),
+        "fail_limit", sol::readonly(&lt::announce_entry::fail_limit),
+        "tier",       sol::readonly(&lt::announce_entry::tier),
+        "trackerid",  sol::readonly(&lt::announce_entry::trackerid),
+        "url",        sol::readonly(&lt::announce_entry::url));
 
-    announce_entry_type["endpoints"] = sol::property([](const lt::announce_entry& ae) { return ae.endpoints; });
-    announce_entry_type["fail_limit"] = sol::property([](const lt::announce_entry& ae) { return ae.fail_limit; });
-    announce_entry_type["source"] = sol::property([](const lt::announce_entry& ae) { return ae.source; });
-    announce_entry_type["tier"] = sol::property([](const lt::announce_entry& ae) { return ae.tier; });
-    announce_entry_type["trackerid"] = sol::property([](const lt::announce_entry& ae) { return ae.trackerid; });
-    announce_entry_type["url"] = sol::property([](const lt::announce_entry& ae) { return ae.url; });
+    announce_entry_type["source"]   = sol::property([](const lt::announce_entry& ae) { return ae.source; });
     announce_entry_type["verified"] = sol::property([](const lt::announce_entry& ae) { return ae.verified; });
 
     auto info_hash_type = lua.new_usertype<lt::info_hash_t>(
@@ -92,43 +92,160 @@ void Torrents::Register(sol::state& lua)
 
     auto peer_info_type = lua.new_usertype<lt::peer_info>(
         "lt.PeerInfo",
-        sol::no_constructor);
+        sol::no_constructor,
+        "busy_requests",         sol::readonly(&lt::peer_info::busy_requests),
+        "client",                sol::readonly(&lt::peer_info::client),
+        "connection_type",       sol::readonly(&lt::peer_info::connection_type),
+        "down_speed",            sol::readonly(&lt::peer_info::down_speed),
+        "download_queue_length", sol::readonly(&lt::peer_info::download_queue_length),
+        "download_queue_time",   sol::readonly(&lt::peer_info::download_queue_time),
+        "flags",                 sol::readonly(&lt::peer_info::flags),
+        "progress",              sol::readonly(&lt::peer_info::progress),
+        "rtt",                   sol::readonly(&lt::peer_info::rtt),
+        "source",                sol::readonly(&lt::peer_info::source),
+        "total_download",        sol::readonly(&lt::peer_info::total_download),
+        "total_upload",          sol::readonly(&lt::peer_info::total_upload),
+        "up_speed",              sol::readonly(&lt::peer_info::up_speed));
 
-    peer_info_type["busy_requests"] = sol::property([](const lt::peer_info& pi) { return pi.busy_requests; });
-    peer_info_type["client"] = sol::property([](const lt::peer_info& pi) { return pi.client; });
-    peer_info_type["connection_type"] = sol::property([](const lt::peer_info& pi) { return pi.connection_type; });
-    peer_info_type["down_speed"] = sol::property([](const lt::peer_info& pi) { return pi.down_speed; });
-    peer_info_type["up_speed"] = sol::property([](const lt::peer_info& pi) { return pi.up_speed; });
-    peer_info_type["download_queue_length"] = sol::property([](const lt::peer_info& pi) { return pi.download_queue_length; });
-    peer_info_type["download_queue_time"] = sol::property([](const lt::peer_info& pi) { return pi.download_queue_time.count(); });
-    peer_info_type["flags"] = sol::property([](const lt::peer_info& pi) { return pi.flags; });
-    // peer_info_type["flags"] = sol::property([](const lt::peer_info& pi) { return pi.flags; });
-    peer_info_type["last_active"] = sol::property([](const lt::peer_info& pi) { return pi.last_active.count(); });
+    peer_info_type["last_active"]  = sol::property([](const lt::peer_info& pi) { return pi.last_active.count(); });
     peer_info_type["last_request"] = sol::property([](const lt::peer_info& pi) { return pi.last_request.count(); });
-    // local endpoint peer_info_type["last_request"] = sol::property([](const lt::peer_info& pi) { return pi.last_request.count(); });
-    peer_info_type["progress"] = sol::property([](const lt::peer_info& pi) { return pi.progress; });
-    peer_info_type["rtt"] = sol::property([](const lt::peer_info& pi) { return pi.rtt; });
-    peer_info_type["source"] = sol::property([](const lt::peer_info& pi) { return pi.source; });
-    peer_info_type["total_download"] = sol::property([](const lt::peer_info& pi) { return pi.total_download; });
-    peer_info_type["total_upload"] = sol::property([](const lt::peer_info& pi) { return pi.total_upload; });
+
+    auto torrent_client_data_type = lua.new_usertype<TorrentClientData>(
+        "porla.TorrentClientData",
+        sol::no_constructor,
+        "category", &TorrentClientData::category,
+        "tags",     &TorrentClientData::tags);
 
     auto torrent_info_type = lua.new_usertype<lt::torrent_info>(
         "lt.TorrentInfo",
-        sol::no_constructor);
+        sol::no_constructor,
+        "comment",    &lt::torrent_info::comment,
+        "creator",    &lt::torrent_info::creator,
+        "info_hash",  &lt::torrent_info::info_hashes,
+        "name",       &lt::torrent_info::name,
+        "num_files",  &lt::torrent_info::num_files,
+        "num_pieces", &lt::torrent_info::num_pieces,
+        "priv",       &lt::torrent_info::priv,
+        "trackers",   &lt::torrent_info::trackers,
+        "total_size", &lt::torrent_info::total_size);
 
-    torrent_info_type["comment"]    = sol::property([](const lt::torrent_info& ti) { return ti.comment(); });
-    torrent_info_type["creator"]    = sol::property([](const lt::torrent_info& ti) { return ti.creator(); });
-    torrent_info_type["info_hash"]  = sol::property([](const lt::torrent_info& ti) { return ti.info_hashes(); });
-    torrent_info_type["name"]       = sol::property([](const lt::torrent_info& ti) { return ti.name(); });
-    torrent_info_type["num_files"]  = sol::property([](const lt::torrent_info& ti) { return ti.num_files(); });
-    torrent_info_type["num_pieces"] = sol::property([](const lt::torrent_info& ti) { return ti.num_pieces(); });
-    torrent_info_type["priv"]       = sol::property([](const lt::torrent_info& ti) { return ti.priv(); });
-    torrent_info_type["trackers"]   = sol::property([](const lt::torrent_info& ti) { return ti.trackers(); });
-    torrent_info_type["total_size"] = sol::property([](const lt::torrent_info& ti) { return ti.total_size(); });
+    auto torrent_handle_type = lua.new_usertype<lt::torrent_handle>(
+        "lt.TorrentHandle",
+        sol::no_constructor,
+        "clear_error",             &lt::torrent_handle::clear_error,
+        "clear_peers",             &lt::torrent_handle::clear_peers,
+        "download_limit",          &lt::torrent_handle::download_limit,
+        "flush_cache",             &lt::torrent_handle::flush_cache,
+        "force_reannounce",        [](const lt::torrent_handle& th, const sol::table& args)
+                                   {
+                                       int seconds = 0;
+                                       int index   = -1;
+
+                                       if (args["seconds"].is<int>())       seconds = args["seconds"];
+                                       if (args["tracker_index"].is<int>()) index   = args["tracker_index"];
+
+                                       th.force_reannounce(seconds, index);
+                                   },
+        "force_recheck",           &lt::torrent_handle::force_recheck,
+        "info_hash",               &lt::torrent_handle::info_hashes,
+        "is_valid",                &lt::torrent_handle::is_valid,
+        "max_connections",         &lt::torrent_handle::max_connections,
+        "max_uploads",             &lt::torrent_handle::max_uploads,
+        "move_storage",            [](const lt::torrent_handle& th, const std::string& path) { th.move_storage(path); },
+        "pause",                   [](const lt::torrent_handle& th) { return th.pause(); },
+        "peer_info",               [](const lt::torrent_handle& th)
+                                   {
+                                       std::vector<lt::peer_info> peers;
+                                       th.get_peer_info(peers);
+                                       return peers;
+                                   },
+        "post_peer_info",          &lt::torrent_handle::post_peer_info,
+        "post_piece_availability", &lt::torrent_handle::post_piece_availability,
+        "post_status",             [](const lt::torrent_handle& th) { return th.post_status(); },
+        "post_trackers",           &lt::torrent_handle::post_trackers,
+        "queue_position",          &lt::torrent_handle::queue_position,
+        "queue_position_bottom",   &lt::torrent_handle::queue_position_bottom,
+        "queue_position_down",     &lt::torrent_handle::queue_position_down,
+        "queue_position_top",      &lt::torrent_handle::queue_position_top,
+        "queue_position_up",       &lt::torrent_handle::queue_position_up,
+        "resume",                  &lt::torrent_handle::resume,
+        "set_download_limit",      &lt::torrent_handle::set_download_limit,
+        "set_max_connections",     &lt::torrent_handle::set_max_connections,
+        "set_max_uploads",         &lt::torrent_handle::set_max_uploads,
+        "set_upload_limit",        &lt::torrent_handle::set_upload_limit,
+        "status",                  [](const lt::torrent_handle& th) { return th.status(); },
+        "trackers",                &lt::torrent_handle::trackers,
+        "upload_limit",            &lt::torrent_handle::upload_limit,
+        "userdata",                [](const lt::torrent_handle& th) { return th.userdata().get<TorrentClientData>(); });
 
     auto torrent_status_type = lua.new_usertype<lt::torrent_status>(
         "lt.TorrentStatus",
-        sol::no_constructor);
+        sol::no_constructor,
+        // active duration
+        // added time
+        "all_time_download",      sol::readonly(&lt::torrent_status::all_time_download),
+        "all_time_upload",        sol::readonly(&lt::torrent_status::all_time_upload),
+        "announcing_to_dht",      sol::readonly(&lt::torrent_status::announcing_to_dht),
+        "announcing_to_lsd",      sol::readonly(&lt::torrent_status::announcing_to_lsd),
+        "announcing_to_trackers", sol::readonly(&lt::torrent_status::announcing_to_trackers),
+        "block_size",             sol::readonly(&lt::torrent_status::block_size),
+        // completed time
+        "connect_candidates",     sol::readonly(&lt::torrent_status::connect_candidates),
+        "connections_limit",      sol::readonly(&lt::torrent_status::connections_limit),
+        "current_tracker",        sol::readonly(&lt::torrent_status::current_tracker),
+        "distributed_copies",     sol::readonly(&lt::torrent_status::distributed_copies),
+        "down_bandwidth_queue",   sol::readonly(&lt::torrent_status::down_bandwidth_queue),
+        "download_payload_rate",  sol::readonly(&lt::torrent_status::download_payload_rate),
+        "download_rate",          sol::readonly(&lt::torrent_status::download_rate),
+        // errc
+        // error_file
+        // finished duration
+        // flags
+        "info_hash",              sol::readonly(&lt::torrent_status::info_hashes),
+        "is_finished",            sol::readonly(&lt::torrent_status::is_finished),
+        "is_seeding",             sol::readonly(&lt::torrent_status::is_seeding),
+        "handle",                 sol::readonly(&lt::torrent_status::handle),
+        "has_incoming",           sol::readonly(&lt::torrent_status::has_incoming),
+        "has_metadata",           sol::readonly(&lt::torrent_status::has_metadata),
+        // last download
+        // last seen complete
+        // last upload
+        "list_peers",             sol::readonly(&lt::torrent_status::list_peers),
+        "list_seeds",             sol::readonly(&lt::torrent_status::list_seeds),
+        "moving_storage",         sol::readonly(&lt::torrent_status::moving_storage),
+        "name",                   sol::readonly(&lt::torrent_status::name),
+        "need_save_resume",       sol::readonly(&lt::torrent_status::need_save_resume),
+        // next announce
+        "num_complete",           sol::readonly(&lt::torrent_status::num_complete),
+        "num_connections",        sol::readonly(&lt::torrent_status::num_connections),
+        "num_incomplete",         sol::readonly(&lt::torrent_status::num_incomplete),
+        "num_peers",              sol::readonly(&lt::torrent_status::num_peers),
+        "num_pieces",             sol::readonly(&lt::torrent_status::num_pieces),
+        "num_seeds",              sol::readonly(&lt::torrent_status::num_seeds),
+        "num_uploads",            sol::readonly(&lt::torrent_status::num_uploads),
+        // pieces
+        "progress",               sol::readonly(&lt::torrent_status::progress),
+        "queue_position",         sol::readonly(&lt::torrent_status::queue_position),
+        "save_path",              sol::readonly(&lt::torrent_status::save_path),
+        "seed_rank",              sol::readonly(&lt::torrent_status::seed_rank),
+        // seeding duration
+        // state
+        // storage mode
+        "torrent_file",           sol::readonly(&lt::torrent_status::torrent_file),
+        "total",                  sol::readonly(&lt::torrent_status::total),
+        "total_done",             sol::readonly(&lt::torrent_status::total_done),
+        "total_download",         sol::readonly(&lt::torrent_status::total_download),
+        "total_failed_bytes",     sol::readonly(&lt::torrent_status::total_failed_bytes),
+        "total_payload_download", sol::readonly(&lt::torrent_status::total_payload_download),
+        "total_payload_upload",   sol::readonly(&lt::torrent_status::total_payload_upload),
+        "total_redundant_bytes",  sol::readonly(&lt::torrent_status::total_redundant_bytes),
+        "total_upload",           sol::readonly(&lt::torrent_status::total_upload),
+        "up_bandwidth_queue",     sol::readonly(&lt::torrent_status::up_bandwidth_queue),
+        "upload_payload_rate",    sol::readonly(&lt::torrent_status::upload_payload_rate),
+        "upload_rate",            sol::readonly(&lt::torrent_status::upload_rate),
+        "uploads_limit",          sol::readonly(&lt::torrent_status::uploads_limit)
+        // verified pieces
+        );
 
     torrent_status_type["category"] = sol::property(
         [](const lt::torrent_status& ts)
@@ -136,20 +253,6 @@ void Torrents::Register(sol::state& lua)
             const TorrentClientData* client_data = ts.handle.userdata().get<TorrentClientData>();
             return client_data->category;
         });
-
-    torrent_status_type["active_duration"]   = sol::property([](const lt::torrent_status& ts) { return ts.active_duration.count(); });
-    torrent_status_type["current_tracker"]   = sol::property([](const lt::torrent_status& ts) { return ts.current_tracker; });
-    torrent_status_type["finished_duration"] = sol::property([](const lt::torrent_status& ts) { return ts.finished_duration.count(); });
-    torrent_status_type["info_hash"]         = sol::property([](const lt::torrent_status& ts) { return ts.info_hashes; });
-    torrent_status_type["is_downloading"]    = sol::property([](const lt::torrent_status& ts) { return ts.state == lt::torrent_status::downloading; });
-    torrent_status_type["is_finished"]       = sol::property([](const lt::torrent_status& ts) { return ts.state == lt::torrent_status::finished; });
-    torrent_status_type["is_moving"]         = sol::property([](const lt::torrent_status& ts) { return ts.moving_storage; });
-    torrent_status_type["is_paused"]         = sol::property([](const lt::torrent_status& ts) { return (ts.flags & lt::torrent_flags::paused) == lt::torrent_flags::paused; });
-    torrent_status_type["is_seeding"]        = sol::property([](const lt::torrent_status& ts) { return ts.state == lt::torrent_status::seeding; });
-    torrent_status_type["name"]              = sol::property([](const lt::torrent_status& ts) { return ts.name; });
-    torrent_status_type["ratio"]             = sol::property([](const lt::torrent_status& ts) { return porla::Utils::Ratio(ts); });
-    torrent_status_type["save_path"]         = sol::property([](const lt::torrent_status& ts) { return ts.save_path; });
-    torrent_status_type["seeding_duration"]  = sol::property([](const lt::torrent_status& ts) { return ts.seeding_duration.count(); });
 
     torrent_status_type["flags"] = sol::property(
         [](const lt::torrent_status& ts)
@@ -179,46 +282,6 @@ void Torrents::Register(sol::state& lua)
             SET_INSERT_FLAG(i2p_torrent)
 
             return flags;
-        });
-
-    torrent_status_type["session"] = sol::property(
-        [](const lt::torrent_status& ts) -> std::optional<std::string>
-        {
-            if (const auto state = ts.handle.userdata().get<TorrentClientData>()->state.lock())
-            {
-                return state->name;
-            }
-
-            return {};
-        });
-
-    torrent_status_type["size"] = sol::property(
-        [](const lt::torrent_status& ts) -> std::optional<std::int64_t>
-        {
-            if (const auto tf = ts.torrent_file.lock())
-            {
-                return tf->total_size();
-            }
-
-            return std::nullopt;
-        });
-
-    torrent_status_type["tags"] = sol::property(
-        [](const lt::torrent_status& ts)
-        {
-            auto client_data = ts.handle.userdata().get<TorrentClientData>();
-
-            if (!client_data->tags.has_value())
-            {
-                client_data->tags = std::unordered_set<std::string>();
-            }
-
-            return *client_data->tags;
-        },
-        [](lt::torrent_status& ts, const std::unordered_set<std::string>& value)
-        {
-            auto client_data = ts.handle.userdata().get<TorrentClientData>();
-            client_data->tags = value;
         });
 
     lua["package"]["preload"]["torrents"] = [](sol::this_state s)
@@ -315,53 +378,6 @@ void Torrents::Register(sol::state& lua)
         torrents["errors"] = lua.create_table();
         torrents["errors"]["tracker_failure"] = lt::errors::tracker_failure;
 
-        torrents["has"] = [](sol::this_state s, const sol::object& arg)
-        {
-            sol::state_view lua{s};
-            const auto options = lua.globals()["__load_opts"].get<const Plugins::PluginLoadOptions&>();
-
-            if (arg.is<std::shared_ptr<lt::torrent_info>>())
-            {
-                const auto ti = arg.as<std::shared_ptr<lt::torrent_info>>();
-
-                return std::find_if(
-                    options.sessions.All().begin(),
-                    options.sessions.All().end(),
-                    [hash = ti->info_hashes()](const auto& state)
-                    {
-                        return state.second->torrents.find(hash) != state.second->torrents.end();
-                    }) != options.sessions.All().end();
-            }
-
-            return false;
-        };
-
-        torrents["list"] = [](sol::this_state s)
-        {
-            sol::state_view lua{s};
-            const auto options = lua.globals()["__load_opts"].get<const Plugins::PluginLoadOptions&>();
-
-            std::vector<lt::torrent_status> ret;
-
-            for (const auto& [ name, state ] : options.sessions.All())
-            {
-                for (const auto& [ hash, handle ]: state->torrents)
-                {
-                    ret.emplace_back(handle.status());
-                }
-            }
-
-            return ret;
-        };
-
-        torrents["move"] = [](const lt::torrent_status& t, const sol::table& args)
-        {
-            if (t.handle.is_valid())
-            {
-                t.handle.move_storage(args["path"]);
-            }
-        };
-
         torrents["parse"] = [](const std::string& data, const std::string& type)
         {
             if (type == "buffer")
@@ -375,31 +391,6 @@ void Torrents::Register(sol::state& lua)
             }
 
             return std::make_shared<lt::torrent_info>(data);
-        };
-
-        torrents["pause"] = [](const lt::torrent_status& ts)
-        {
-            if (ts.handle.is_valid())
-            {
-                ts.handle.pause();
-            }
-            else
-            {
-                BOOST_LOG_TRIVIAL(error) << "Torrent not valid";
-            }
-        };
-
-        torrents["peers"] = lua.create_table();
-        torrents["peers"]["list"] = [](const lt::torrent_status& ts)
-        {
-            if (!ts.handle.is_valid())
-            {
-                BOOST_LOG_TRIVIAL(error) << "Invalid torrent handle";
-            }
-
-            std::vector<lt::peer_info> peers;
-            ts.handle.get_peer_info(peers);
-            return peers;
         };
 
         torrents["properties"] = lua.create_table();
@@ -437,11 +428,7 @@ void Torrents::Register(sol::state& lua)
             INSERT_FLAG(default_dont_download)
             INSERT_FLAG(i2p_torrent)
 
-            p["download_limit"]  = ts.handle.download_limit();
             p["flags"]           = flags;
-            p["max_connections"] = ts.handle.max_connections();
-            p["max_uploads"]     = ts.handle.max_uploads();
-            p["upload_limit"]    = ts.handle.upload_limit();
 
             return p;
         };
@@ -491,76 +478,8 @@ void Torrents::Register(sol::state& lua)
                 SET_FLAG(default_dont_download)
                 SET_FLAG(i2p_torrent)
 
-                BOOST_LOG_TRIVIAL(info) << flags << ", " << mask;
-
                 ts.handle.set_flags(flags, mask);
             }
-
-            if (args["download_limit"].valid())  ts.handle.set_download_limit(args["download_limit"]);
-            if (args["max_connections"].valid()) ts.handle.set_max_connections(args["max_connections"]);
-            if (args["max_uploads"].valid())     ts.handle.set_max_uploads(args["max_uploads"]);
-            if (args["upload_limit"].valid())    ts.handle.set_upload_limit(args["upload_limit"]);
-        };
-
-        torrents["reannounce"] = [](sol::this_state s, const lt::torrent_status& ts, const sol::table& args)
-        {
-            if (!ts.handle.is_valid())
-            {
-                return;
-            }
-
-            int                    seconds = 0;
-            int                    index   = -1;
-
-            if (args["seconds"].is<int>())       seconds = args["seconds"];
-            if (args["tracker_index"].is<int>()) index   = args["tracker_index"];
-
-            ts.handle.force_reannounce(seconds, index);
-        };
-
-        torrents["remove"] = [](sol::this_state s, const lt::torrent_status& ts, const sol::table& args)
-        {
-            sol::state_view lua{s};
-            const auto options = lua.globals()["__load_opts"].get<const Plugins::PluginLoadOptions&>();
-            const auto& state  = std::find_if(
-                options.sessions.All().begin(),
-                options.sessions.All().end(),
-                [hash = ts.info_hashes](const auto& state)
-                {
-                    return state.second->torrents.find(hash) != state.second->torrents.end();
-                });
-
-            bool remove_files = false;
-            if (args["remove_files"].valid()) { remove_files = args["remove_files"].get<bool>(); }
-
-            state->second->session->remove_torrent(
-                ts.handle,
-                remove_files ? lt::session::delete_files : lt::remove_flags_t{});
-        };
-
-        torrents["resume"] = [](sol::this_state s, const lt::torrent_status& ts)
-        {
-            sol::state_view lua{s};
-
-            if (ts.handle.is_valid())
-            {
-                ts.handle.resume();
-            }
-            else
-            {
-                BOOST_LOG_TRIVIAL(error) << "Torrent not valid";
-            }
-        };
-
-        torrents["trackers"] = lua.create_table();
-        torrents["trackers"]["list"] = [](const lt::torrent_status& ts)
-        {
-            if (!ts.handle.is_valid())
-            {
-                BOOST_LOG_TRIVIAL(error) << "Invalid torrent handle";
-            }
-
-            return ts.handle.trackers();
         };
 
         return torrents;

--- a/src/lua/packages/torrents.cpp
+++ b/src/lua/packages/torrents.cpp
@@ -264,7 +264,7 @@ void Torrents::Register(sol::state& lua)
     auto torrent_status_type = lua.new_usertype<lt::torrent_status>(
         "lt.TorrentStatus",
         sol::no_constructor,
-        // active duration
+        "active_duration",        sol::property([](const lt::torrent_status& ts) { return ts.active_duration.count(); }),
         // added time
         "all_time_download",      sol::readonly(&lt::torrent_status::all_time_download),
         "all_time_upload",        sol::readonly(&lt::torrent_status::all_time_upload),
@@ -282,7 +282,7 @@ void Torrents::Register(sol::state& lua)
         "download_rate",          sol::readonly(&lt::torrent_status::download_rate),
         // errc
         // error_file
-        // finished duration
+        "finished_duration",      sol::property([](const lt::torrent_status& ts) { return ts.finished_duration.count(); }),
         "flags",                  sol::property([](const lt::torrent_status& ts) { return FlagsToMap(ts.flags); }),
         "info_hash",              sol::readonly(&lt::torrent_status::info_hashes),
         "is_finished",            sol::readonly(&lt::torrent_status::is_finished),
@@ -311,10 +311,14 @@ void Torrents::Register(sol::state& lua)
         "queue_position",         sol::readonly(&lt::torrent_status::queue_position),
         "save_path",              sol::readonly(&lt::torrent_status::save_path),
         "seed_rank",              sol::readonly(&lt::torrent_status::seed_rank),
-        // seeding duration
+        "seeding_duration",       sol::property([](const lt::torrent_status& ts) { return ts.seeding_duration.count(); }),
         // state
         // storage mode
-        "torrent_file",           sol::readonly(&lt::torrent_status::torrent_file),
+        "torrent_file",           sol::property([](const lt::torrent_status& ts) -> std::shared_ptr<const lt::torrent_info>
+                                  {
+                                      if (auto tf = ts.torrent_file.lock()) return tf;
+                                      return nullptr;
+                                  }),
         "total",                  sol::readonly(&lt::torrent_status::total),
         "total_done",             sol::readonly(&lt::torrent_status::total_done),
         "total_download",         sol::readonly(&lt::torrent_status::total_download),

--- a/src/lua/plugins/plugin.cpp
+++ b/src/lua/plugins/plugin.cpp
@@ -11,6 +11,7 @@
 #include "../packages/json.hpp"
 #include "../packages/log.hpp"
 #include "../packages/pql.hpp"
+#include "../packages/presets.hpp"
 #include "../packages/process.hpp"
 #include "../packages/sessions.hpp"
 #include "../packages/sqlite.hpp"
@@ -76,6 +77,7 @@ std::unique_ptr<Plugin> Plugin::Load(const PluginLoadOptions& opts)
     Packages::Json::Register(state->lua);
     Packages::Log::Register(state->lua);
     Packages::PQL::Register(state->lua);
+    Packages::Presets::Register(state->lua);
     Packages::Process::Register(state->lua);
     Packages::Sessions::Register(state->lua);
     Packages::Sqlite::Register(state->lua);

--- a/src/sessions.cpp
+++ b/src/sessions.cpp
@@ -427,7 +427,12 @@ void Sessions::ReadAlerts(const std::shared_ptr<SessionState>& state)
                     | lt::torrent_handle::save_info_dict
                     | lt::torrent_handle::only_if_modified);
 
-                boost::asio::post(m_options.io, [this, state, status](){ m_torrent_added(state->name, status); });
+                boost::asio::post(
+                    m_options.io,
+                    [this, state, handle = ata->handle]()
+                    {
+                        m_torrent_added(state->name, handle);
+                    });
 
                 break;
             }
@@ -541,7 +546,12 @@ void Sessions::ReadAlerts(const std::shared_ptr<SessionState>& state)
                     // Only emit this event if we have downloaded any data this session
                     BOOST_LOG_TRIVIAL(info) << "Torrent " << status.name << " finished";
 
-                    boost::asio::post(m_options.io, [this, state, status](){ m_torrent_finished(state->name, status); });
+                    boost::asio::post(
+                        m_options.io,
+                        [this, state, handle = tfa->handle]()
+                        {
+                            m_torrent_finished(state->name, handle);
+                        });
                 }
 
                 if (status.need_save_resume)
@@ -585,7 +595,12 @@ void Sessions::ReadAlerts(const std::shared_ptr<SessionState>& state)
 
                 BOOST_LOG_TRIVIAL(debug) << "Torrent " << status.name << " resumed";
 
-                boost::asio::post(m_options.io, [this, state, status](){ m_torrent_resumed(state->name, status); });
+                boost::asio::post(
+                    m_options.io,
+                    [this, state, handle = tra->handle]()
+                    {
+                        m_torrent_resumed(state->name, handle);
+                    });
 
                 break;
             }

--- a/src/sessions.hpp
+++ b/src/sessions.hpp
@@ -52,7 +52,6 @@ namespace porla
         typedef boost::signals2::signal<void(const std::string& session, const libtorrent::info_hash_t&)> InfoHashSignal;
         typedef boost::signals2::signal<void(const std::string& session, const lt::span<const int64_t>&)> SessionStatsSignal;
         typedef boost::signals2::signal<void(const std::string& session, const libtorrent::torrent_handle&)> TorrentHandleSignal;
-        typedef boost::signals2::signal<void(const std::string& session, const libtorrent::torrent_status&)> TorrentStatusSignal;
         typedef boost::signals2::signal<void(const std::string& session, const std::vector<libtorrent::torrent_status>&)> TorrentStatusListSignal;
 
         explicit Sessions(const SessionsOptions& options);
@@ -79,12 +78,12 @@ namespace porla
             return m_storage_moved.connect(subscriber);
         }
 
-        boost::signals2::connection OnTorrentAdded(const TorrentStatusSignal::slot_type& subscriber)
+        boost::signals2::connection OnTorrentAdded(const TorrentHandleSignal::slot_type& subscriber)
         {
             return m_torrent_added.connect(subscriber);
         }
 
-        boost::signals2::connection OnTorrentFinished(const TorrentStatusSignal::slot_type& subscriber)
+        boost::signals2::connection OnTorrentFinished(const TorrentHandleSignal::slot_type& subscriber)
         {
             return m_torrent_finished.connect(subscriber);
         }
@@ -99,7 +98,7 @@ namespace porla
             return m_torrent_removed.connect(subscriber);
         }
 
-        boost::signals2::connection OnTorrentResumed(const TorrentStatusSignal::slot_type& subscriber)
+        boost::signals2::connection OnTorrentResumed(const TorrentHandleSignal::slot_type& subscriber)
         {
             return m_torrent_resumed.connect(subscriber);
         }
@@ -120,10 +119,10 @@ namespace porla
         SessionStatsSignal m_session_stats;
         TorrentStatusListSignal m_state_update;
         TorrentHandleSignal m_storage_moved;
-        TorrentStatusSignal m_torrent_added;
-        TorrentStatusSignal m_torrent_finished;
+        TorrentHandleSignal m_torrent_added;
+        TorrentHandleSignal m_torrent_finished;
         TorrentHandleSignal m_torrent_paused;
         InfoHashSignal m_torrent_removed;
-        TorrentStatusSignal m_torrent_resumed;
+        TorrentHandleSignal m_torrent_resumed;
     };
 }


### PR DESCRIPTION
Lots of breaking changes in this one re: plugins and workflows. Nothing major but many small things. The Lua API now maps much closer to the libtorrent API and we have torrent handles and torrent statuses to work with.

```lua
local sessions = require("sessions")

function porla.init()
    for session in sessions.list() do
        print(string.format("torrents in %s", session.name))

        for torrent in session:torrents() do
            -- torrent is an lt::torrent_handle

            local ts = torrent:status() -- ts is an lt::torrent_status

            print(ts.name)
        end
    end
end

```