### PR TITLE
feat(lua): treat workflows as plugins

### DIFF
--- a/src/json/pluginslist.hpp
+++ b/src/json/pluginslist.hpp
@@ -18,6 +18,8 @@ namespace porla::Methods
 
     NLOHMANN_JSONIFY_ALL_THINGS(
         PluginsListRes::Plugin,
+        can_configure,
+        can_uninstall,
         name,
         path,
         version_info)

--- a/src/lua/plugins/pluginengine.hpp
+++ b/src/lua/plugins/pluginengine.hpp
@@ -29,6 +29,8 @@ namespace porla::Lua::Plugins
 
     struct PluginState
     {
+        bool                       can_configure;
+        bool                       can_uninstall;
         std::optional<std::string> config;
         std::filesystem::path      path;
         std::unique_ptr<Plugin>    plugin;
@@ -58,6 +60,5 @@ namespace porla::Lua::Plugins
     private:
         PluginEngineOptions m_options;
         std::map<std::string, PluginState> m_plugins;
-        std::vector<std::unique_ptr<Plugin>> m_workflows;
     };
 }

--- a/src/methods/plugins/pluginslist.cpp
+++ b/src/methods/plugins/pluginslist.cpp
@@ -27,8 +27,10 @@ void PluginsList::Invoke(const PluginsListReq& req, WriteCb<PluginsListRes> cb)
         std::string abs_path = fs::absolute(state.path);
 
         PluginsListRes::Plugin plugin{
-            .name = name,
-            .path = abs_path
+            .can_configure = state.can_configure,
+            .can_uninstall = state.can_uninstall,
+            .name          = name,
+            .path          = abs_path
         };
 
         git_repository* repo;

--- a/src/methods/plugins/pluginslist_reqres.hpp
+++ b/src/methods/plugins/pluginslist_reqres.hpp
@@ -19,6 +19,8 @@ namespace porla::Methods
 
         struct Plugin
         {
+            bool                       can_configure;
+            bool                       can_uninstall;
             std::string                name;
             fs::path                   path;
             std::optional<VersionInfo> version_info;


### PR DESCRIPTION
Workflows are single-file plugins.

You can now see workflows in the plugin list in the web UI, as well as reload them. Uninstalling and configuring workflows is disabled.