### PR TITLE
feat(lua): add os package, add process.search_path, add app config

### DIFF
--- a/src/lua/packages/config.cpp
+++ b/src/lua/packages/config.cpp
@@ -9,6 +9,16 @@ using porla::Lua::Packages::Config;
 
 void Config::Register(sol::state& lua)
 {
+    lua["package"]["preload"]["config.app"] = [](sol::this_state s)
+    {
+        sol::state_view lua{s};
+        const auto& options = lua.globals()["__load_opts"].get<const Plugins::PluginLoadOptions&>();
+
+        sol::table t = lua.create_table();
+        t["db_file"] = options.config.db_file;
+        return t;
+    };
+
     lua["package"]["preload"]["config"] = [](sol::this_state s) -> sol::object
     {
         sol::state_view lua{s};

--- a/src/lua/packages/process.cpp
+++ b/src/lua/packages/process.cpp
@@ -65,10 +65,15 @@ void Process::Register(sol::state& lua)
     lua["package"]["preload"]["process"] = [](sol::this_state s)
     {
         sol::state_view lua{s};
-        sol::table log = lua.create_table();
+        sol::table process = lua.create_table();
 
-        log["launch"] = &Launch;
+        process["launch"] = &Launch;
 
-        return log;
+        process["search_path"] = [](const std::string& path)
+        {
+            return bp::search_path(path).string();
+        };
+
+        return process;
     };
 }

--- a/src/lua/plugins/plugin.cpp
+++ b/src/lua/plugins/plugin.cpp
@@ -55,6 +55,7 @@ std::unique_ptr<Plugin> Plugin::Load(const PluginLoadOptions& opts)
     state->lua.open_libraries(
         sol::lib::base,
         sol::lib::io,
+        sol::lib::os,
         sol::lib::package,
         sol::lib::string,
         sol::lib::table);


### PR DESCRIPTION
The `os` package makes it possible to do some basic date formatting, the `process.search_path` searches the path for a binary, the `config.app` gives us the app config where the database file path is.

All these are added to support the backup plugin that can backup the Porla database on a schedule.