### PR TITLE
feat(lua): emit event when `file_error_alert` occurs

### DIFF
--- a/src/lua/packages/events.cpp
+++ b/src/lua/packages/events.cpp
@@ -64,6 +64,24 @@ void Events::Register(sol::state& lua)
                 return std::make_shared<SignalConnection>(connection);
             }
 
+            if (name == "torrent_file_error")
+            {
+                auto connection = options.sessions.OnTorrentFileError(
+                    [cb = callback](const std::string& session, const porla::Sessions::TorrentFileErrorEvent& evt)
+                    {
+                        try
+                        {
+                            cb(evt.torrent, evt.file);
+                        }
+                        catch (const sol::error& err)
+                        {
+                            BOOST_LOG_TRIVIAL(error) << "An error occurred in an event handler: " << err.what();
+                        }
+                    });
+
+                return std::make_shared<SignalConnection>(connection);
+            }
+
             if (name == "torrent_finished")
             {
                 auto connection = options.sessions.OnTorrentFinished(

--- a/src/sessions.cpp
+++ b/src/sessions.cpp
@@ -436,6 +436,19 @@ void Sessions::ReadAlerts(const std::shared_ptr<SessionState>& state)
 
                 break;
             }
+            case lt::file_error_alert::alert_type:
+            {
+                const auto fea = lt::alert_cast<lt::file_error_alert>(alert);
+
+                TorrentFileErrorEvent evt{
+                    .file = fea->filename(),
+                    .torrent = fea->handle
+                };
+
+                boost::asio::post(m_options.io, [this, evt, state](){ m_torrent_file_error(state->name, evt); });
+
+                break;
+            }
             case lt::metadata_received_alert::alert_type:
             {
                 auto mra = lt::alert_cast<lt::metadata_received_alert>(alert);

--- a/src/sessions.hpp
+++ b/src/sessions.hpp
@@ -34,6 +34,12 @@ namespace porla
     public:
         static bool DisallowedSetting(const std::string& name);
 
+        struct TorrentFileErrorEvent
+        {
+            std::string        file;
+            lt::torrent_handle torrent;
+        };
+
         struct SessionState
         {
             friend class Sessions;
@@ -51,6 +57,7 @@ namespace porla
 
         typedef boost::signals2::signal<void(const std::string& session, const libtorrent::info_hash_t&)> InfoHashSignal;
         typedef boost::signals2::signal<void(const std::string& session, const lt::span<const int64_t>&)> SessionStatsSignal;
+        typedef boost::signals2::signal<void(const std::string& session, const TorrentFileErrorEvent&)> TorrentFileErrorSignal;
         typedef boost::signals2::signal<void(const std::string& session, const libtorrent::torrent_handle&)> TorrentHandleSignal;
         typedef boost::signals2::signal<void(const std::string& session, const std::vector<libtorrent::torrent_status>&)> TorrentStatusListSignal;
 
@@ -81,6 +88,11 @@ namespace porla
         boost::signals2::connection OnTorrentAdded(const TorrentHandleSignal::slot_type& subscriber)
         {
             return m_torrent_added.connect(subscriber);
+        }
+
+        boost::signals2::connection OnTorrentFileError(const TorrentFileErrorSignal::slot_type& subscriber)
+        {
+            return m_torrent_file_error.connect(subscriber);
         }
 
         boost::signals2::connection OnTorrentFinished(const TorrentHandleSignal::slot_type& subscriber)
@@ -120,6 +132,7 @@ namespace porla
         TorrentStatusListSignal m_state_update;
         TorrentHandleSignal m_storage_moved;
         TorrentHandleSignal m_torrent_added;
+        TorrentFileErrorSignal m_torrent_file_error;
         TorrentHandleSignal m_torrent_finished;
         TorrentHandleSignal m_torrent_paused;
         InfoHashSignal m_torrent_removed;


### PR DESCRIPTION
```lua
local events = require("events")

events.on("torrent_file_error", function(torrent, file)
    -- torrent is a TorrentHandle
    -- file is the file name
end)
```