### PR TITLE
fix(api): put presets in a subkey

### DIFF
--- a/html/src/components/AddTorrentModal.tsx
+++ b/html/src/components/AddTorrentModal.tsx
@@ -54,7 +54,7 @@ type AddTorrentModalProps = {
 }
 
 export default function AddTorrentModal(props: AddTorrentModalProps) {
-  const { presets } = props;
+  const { presets } = props.presets;
 
   const fsSpace             = useInvoker<any>("fs.space");
   const torrentsAdd         = useInvoker<InfoHash>("torrents.add");
@@ -71,8 +71,8 @@ export default function AddTorrentModal(props: AddTorrentModalProps) {
   }, [path]);
 
   useEffect(() => {
-    if (props.presets.default && props.presets.default.save_path) {
-      setPath(() => props.presets.default.save_path!);
+    if (presets.default && presets.default.save_path) {
+      setPath(() => presets.default.save_path!);
     }
   }, []);
 

--- a/html/src/types/index.tsx
+++ b/html/src/types/index.tsx
@@ -4,7 +4,9 @@ type AddTorrentParams = {
 }
 
 export type PresetsList = {
-  [id: string] : Preset;
+  presets: {
+    [id: string] : Preset;
+  }
 };
 
 export type Preset = {

--- a/src/json/presetslist.hpp
+++ b/src/json/presetslist.hpp
@@ -15,18 +15,21 @@ namespace porla::Methods
 
     static void to_json(json& j, const PresetsListRes& res)
     {
-        j = json::object();
+        j = {
+            {"presets", json::object()}
+        };
+
         for (auto const& [key,preset] : res.presets)
         {
-            j[key] = json::object();
-            j[key]["category"]        = preset.category        ? json(preset.category.value())        : json();
-            j[key]["download_limit"]  = preset.download_limit  ? json(preset.download_limit.value())  : json();
-            j[key]["max_connections"] = preset.max_connections ? json(preset.max_connections.value()) : json();
-            j[key]["max_uploads"]     = preset.max_uploads     ? json(preset.max_uploads.value())     : json();
-            j[key]["save_path"]       = preset.save_path       ? json(preset.save_path.value())       : json();
-            j[key]["session"]         = preset.session         ? json(preset.session.value())         : json();
-            j[key]["tags"]            = !preset.tags.empty()   ? json(preset.tags)                    : json();
-            j[key]["upload_limit"]    = preset.upload_limit    ? json(preset.upload_limit.value())    : json();
+            j["presets"][key] = json::object();
+            j["presets"][key]["category"]        = preset.category        ? json(preset.category.value())        : json();
+            j["presets"][key]["download_limit"]  = preset.download_limit  ? json(preset.download_limit.value())  : json();
+            j["presets"][key]["max_connections"] = preset.max_connections ? json(preset.max_connections.value()) : json();
+            j["presets"][key]["max_uploads"]     = preset.max_uploads     ? json(preset.max_uploads.value())     : json();
+            j["presets"][key]["save_path"]       = preset.save_path       ? json(preset.save_path.value())       : json();
+            j["presets"][key]["session"]         = preset.session         ? json(preset.session.value())         : json();
+            j["presets"][key]["tags"]            = !preset.tags.empty()   ? json(preset.tags)                    : json();
+            j["presets"][key]["upload_limit"]    = preset.upload_limit    ? json(preset.upload_limit.value())    : json();
         }
     }
 }


### PR DESCRIPTION
This moves the presets from the `presets.list` result from being an array directly in results to being an array in the property `presets` of the result.