### PR TITLE
feat: cache lt::torrent status

### DIFF
--- a/src/lua/packages/sessions.cpp
+++ b/src/lua/packages/sessions.cpp
@@ -48,14 +48,14 @@ public:
     {
         if (m_iter == m_state.torrents.end()) return std::nullopt;
 
-        auto th = m_iter->second;
+        const auto& [ th, _ ] = m_iter->second;
         std::advance(m_iter, 1);
         return th;
     }
 
 private:
     const porla::Sessions::SessionState& m_state;
-    std::map<lt::info_hash_t, lt::torrent_handle>::const_iterator m_iter;
+    std::map<lt::info_hash_t, std::tuple<lt::torrent_handle, lt::torrent_status>>::const_iterator m_iter;
 };
 
 void Sessions::Register(sol::state& lua)
@@ -196,7 +196,9 @@ void Sessions::Register(sol::state& lua)
             return std::nullopt;
         }
 
-        return it->second;
+        const auto& [ th, _ ] = it->second;
+
+        return th;
     };
 
     session_type["remove_torrent"] = [](const porla::Sessions::SessionState& state, const lt::torrent_handle& th, const sol::table& args)

--- a/src/methods/torrentsfileslist.cpp
+++ b/src/methods/torrentsfileslist.cpp
@@ -35,7 +35,7 @@ void TorrentsFilesList::Invoke(const TorrentsFilesListReq& req, WriteCb<Torrents
         return cb.Error(-1, "Torrent not found");
     }
 
-    const auto& status = handle->second.status();
+    const auto& [ _, status ] = handle->second;
 
     TorrentsFilesListRes res;
 

--- a/src/methods/torrentslist.cpp
+++ b/src/methods/torrentslist.cpp
@@ -105,8 +105,10 @@ void TorrentsList::Invoke(const TorrentsListReq& req, WriteCb<TorrentsListRes> c
 
     for (const auto& [ name, state] : m_sessions.All())
     {
-        for (auto const& [_, handle] : state->torrents)
+        for (const auto& [_, pair] : state->torrents)
         {
+            const auto& [ handle, ts ] = pair;
+
             if (!handle.is_valid())
             {
                 continue;
@@ -137,8 +139,6 @@ void TorrentsList::Invoke(const TorrentsListReq& req, WriteCb<TorrentsListRes> c
                     }
                 }
             }
-
-            auto const& ts = handle.status();
 
             if (auto ti = ts.torrent_file.lock())
                 size = ti->total_size();

--- a/src/methods/torrentsmetadatalist.cpp
+++ b/src/methods/torrentsmetadatalist.cpp
@@ -35,7 +35,8 @@ void TorrentsMetadataList::Invoke(const TorrentsMetadataListReq& req, WriteCb<To
         return cb.Error(-1, "Torrent not found");
     }
 
-    const auto client_data = handle->second.userdata().get<TorrentClientData>();
+    const auto& [ th, _ ] = handle->second;
+    const auto& client_data = th.userdata().get<TorrentClientData>();
 
     return cb.Ok(TorrentsMetadataListRes{
         .metadata = client_data->metadata.has_value()

--- a/src/methods/torrentsmove.cpp
+++ b/src/methods/torrentsmove.cpp
@@ -42,7 +42,9 @@ void TorrentsMove::Invoke(const TorrentsMoveReq &req, WriteCb<TorrentsMoveRes> c
         if (req.flags.value() == "fail_if_exist")        flags = lt::move_flags_t::fail_if_exist;
     }
 
-    handle->second.move_storage(req.path, flags);
+    const auto& [ th, _ ] = handle->second;
+
+    th.move_storage(req.path, flags);
 
     return cb.Ok(TorrentsMoveRes{});
 }

--- a/src/methods/torrentspause.cpp
+++ b/src/methods/torrentspause.cpp
@@ -33,7 +33,9 @@ void TorrentsPause::Invoke(const TorrentsPauseReq& req, WriteCb<TorrentsPauseRes
         return cb.Error(-1, "Torrent not found");
     }
 
-    handle->second.pause();
+    const auto& [ th, _ ] = handle->second;
+
+    th.pause();
 
     cb.Ok(TorrentsPauseRes{});
 }

--- a/src/methods/torrentspeersadd.cpp
+++ b/src/methods/torrentspeersadd.cpp
@@ -35,6 +35,8 @@ void TorrentsPeersAdd::Invoke(const TorrentsPeersAddReq& req, WriteCb<TorrentsPe
         return cb.Error(-1, "Torrent not found");
     }
 
+    const auto& [ th, _ ] = handle->second;
+
     for (const auto& [ip,port] : req.peers)
     {
         boost::system::error_code ec;
@@ -46,7 +48,7 @@ void TorrentsPeersAdd::Invoke(const TorrentsPeersAddReq& req, WriteCb<TorrentsPe
             continue;
         }
 
-        handle->second.connect_peer(boost::asio::ip::tcp::endpoint{addr,port});
+        th.connect_peer(boost::asio::ip::tcp::endpoint{addr,port});
     }
 
     cb(TorrentsPeersAddRes{});

--- a/src/methods/torrentspeerslist.cpp
+++ b/src/methods/torrentspeerslist.cpp
@@ -31,8 +31,10 @@ void TorrentsPeersList::Invoke(const TorrentsPeersListReq& req, WriteCb<Torrents
         return cb.Error(-1, "Torrent not found");
     }
 
+    const auto& [ th, _ ] = handle->second;
+
     std::vector<lt::peer_info> peers;
-    handle->second.get_peer_info(peers);
+    th.get_peer_info(peers);
 
     cb.Ok(TorrentsPeersListRes{
         .peers = peers

--- a/src/methods/torrentspropertiesget.cpp
+++ b/src/methods/torrentspropertiesget.cpp
@@ -33,7 +33,9 @@ void TorrentsPropertiesGet::Invoke(const TorrentsPropertiesGetReq& req, WriteCb<
         return cb.Error(-1, "Torrent not found");
     }
 
-    const auto handle_flags = handle->second.flags();
+    const auto& [ th, _ ] = handle->second;
+
+    const auto handle_flags = th.flags();
 
 #define INSERT_FLAG(name) flags.insert({ #name, (handle_flags & lt::torrent_flags:: name) == lt::torrent_flags:: name });
 
@@ -60,10 +62,10 @@ void TorrentsPropertiesGet::Invoke(const TorrentsPropertiesGetReq& req, WriteCb<
     INSERT_FLAG(i2p_torrent)
 
     cb.Ok(TorrentsPropertiesGetRes{
-        .download_limit  = handle->second.download_limit(),
+        .download_limit  = th.download_limit(),
         .flags           = flags,
-        .max_connections = handle->second.max_connections(),
-        .max_uploads     = handle->second.max_uploads(),
-        .upload_limit    = handle->second.upload_limit()
+        .max_connections = th.max_connections(),
+        .max_uploads     = th.max_uploads(),
+        .upload_limit    = th.upload_limit()
     });
 }

--- a/src/methods/torrentspropertiesset.cpp
+++ b/src/methods/torrentspropertiesset.cpp
@@ -33,8 +33,10 @@ void TorrentsPropertiesSet::Invoke(const TorrentsPropertiesSetReq& req, WriteCb<
         return cb.Error(-1, "Torrent not found");
     }
 
+    const auto& [ th, _ ] = handle->second;
+
     if (const auto val = req.download_limit)
-        handle->second.set_download_limit(*val);
+        th.set_download_limit(*val);
 
     if (const auto val = req.flags)
     {
@@ -68,17 +70,17 @@ void TorrentsPropertiesSet::Invoke(const TorrentsPropertiesSetReq& req, WriteCb<
             SET_FLAG(i2p_torrent)
         }
 
-        handle->second.set_flags(flags, mask);
+        th.set_flags(flags, mask);
     }
 
     if (const auto val = req.max_connections)
-        handle->second.set_max_connections(*val);
+        th.set_max_connections(*val);
 
     if (const auto val = req.max_uploads)
-        handle->second.set_max_uploads(*val);
+        th.set_max_uploads(*val);
 
     if (const auto val = req.upload_limit)
-        handle->second.set_upload_limit(*val);
+        th.set_upload_limit(*val);
 
     cb.Ok({});
 }

--- a/src/methods/torrentsrecheck.cpp
+++ b/src/methods/torrentsrecheck.cpp
@@ -36,7 +36,9 @@ void TorrentsRecheck::Invoke(const TorrentsRecheckReq &req, WriteCb<TorrentsRech
         return cb.Error(-1, "Torrent not found");
     }
 
-    state->second->Recheck(handle->second.info_hashes());
+    const auto& [ th, _ ] = handle->second;
+
+    state->second->Recheck(th.info_hashes());
 
     return cb.Ok(TorrentsRecheckRes{});
 }

--- a/src/methods/torrentsremove.cpp
+++ b/src/methods/torrentsremove.cpp
@@ -35,8 +35,10 @@ void TorrentsRemove::Invoke(const TorrentsRemoveReq &req, WriteCb<TorrentsRemove
             continue;
         }
 
+        const auto& [ th, _ ] = handle->second;
+
         state->second->session->remove_torrent(
-            handle->second,
+            th,
             req.remove_data ? lt::session::delete_files : lt::remove_flags_t{});
     }
 

--- a/src/methods/torrentsresume.cpp
+++ b/src/methods/torrentsresume.cpp
@@ -33,7 +33,9 @@ void TorrentsResume::Invoke(const TorrentsResumeReq& req, WriteCb<TorrentsResume
         return cb.Error(-1, "Torrent not found");
     }
 
-    handle->second.resume();
+    const auto& [ th, _ ] = handle->second;
+
+    th.resume();
 
     cb.Ok(TorrentsResumeRes{});
 }

--- a/src/methods/torrentstrackerslist.cpp
+++ b/src/methods/torrentstrackerslist.cpp
@@ -33,7 +33,9 @@ void TorrentsTrackersList::Invoke(const TorrentsTrackersListReq& req, WriteCb<To
         return cb.Error(-1, "Torrent not found");
     }
 
+    const auto& [ th, _ ] = handle->second;
+
     cb.Ok(TorrentsTrackersListRes{
-        .trackers = handle->second.trackers()
+        .trackers = th.trackers()
     });
 }

--- a/src/sessions.cpp
+++ b/src/sessions.cpp
@@ -493,6 +493,11 @@ void Sessions::ReadAlerts(const std::shared_ptr<SessionState>& state)
             {
                 auto sua = lt::alert_cast<lt::state_update_alert>(alert);
 
+                for (const auto& status : sua->status)
+                {
+                    state->torrents.at(status.info_hashes) = std::make_pair(status.handle, status);
+                }
+
                 boost::asio::post(m_options.io, [this, state, status = sua->status](){ m_state_update(state->name, status); });
 
                 break;
@@ -511,6 +516,8 @@ void Sessions::ReadAlerts(const std::shared_ptr<SessionState>& state)
                         | lt::torrent_handle::only_if_modified);
                 }
 
+                state->torrents.at(sma->handle.info_hashes()) = std::make_pair(sma->handle, sma->handle.status());
+
                 boost::asio::post(m_options.io, [this, state, th = sma->handle](){ m_storage_moved(state->name, th); });
 
                 break;
@@ -520,6 +527,8 @@ void Sessions::ReadAlerts(const std::shared_ptr<SessionState>& state)
                 const auto tca = lt::alert_cast<lt::torrent_checked_alert>(alert);
 
                 BOOST_LOG_TRIVIAL(info) << "Torrent " << tca->torrent_name() << " finished checking";
+
+                state->torrents.at(tca->handle.info_hashes()) = std::make_pair(tca->handle, tca->handle.status());
 
                 if (state->m_oneshot_torrent_callbacks.contains({ alert->type(), tca->handle.info_hashes()}))
                 {
@@ -544,6 +553,8 @@ void Sessions::ReadAlerts(const std::shared_ptr<SessionState>& state)
 
                 const auto has_signaled_finished = contains_signaled_finished
                     && client_data->metadata.value()["signal:finished"] == true;
+
+                state->torrents.at(tfa->handle.info_hashes()) = std::make_pair(tfa->handle, status);
 
                 // A torrent finished signal should only be emitted once per
                 // torrent. If we emit this signal, store it in the torrent metadata.
@@ -584,6 +595,8 @@ void Sessions::ReadAlerts(const std::shared_ptr<SessionState>& state)
 
                 BOOST_LOG_TRIVIAL(debug) << "Torrent " << tpa->torrent_name() << " paused";
 
+                state->torrents.at(tpa->handle.info_hashes()) = std::make_pair(tpa->handle, tpa->handle.status());
+
                 boost::asio::post(m_options.io, [this, state, th = tpa->handle](){ m_torrent_paused(state->name, th); });
 
                 break;
@@ -608,6 +621,8 @@ void Sessions::ReadAlerts(const std::shared_ptr<SessionState>& state)
                 auto const& status = tra->handle.status();
 
                 BOOST_LOG_TRIVIAL(debug) << "Torrent " << status.name << " resumed";
+
+                state->torrents.at(tra->handle.info_hashes()) = std::make_pair(tra->handle, status);
 
                 boost::asio::post(
                     m_options.io,

--- a/src/sessions.hpp
+++ b/src/sessions.hpp
@@ -44,10 +44,10 @@ namespace porla
         {
             friend class Sessions;
 
-            std::string                                   name;
-            std::shared_ptr<lt::session>                  session;
-            std::filesystem::path                         session_params_file;
-            std::map<lt::info_hash_t, lt::torrent_handle> torrents;
+            std::string                                                                   name;
+            std::shared_ptr<lt::session>                                                  session;
+            std::filesystem::path                                                         session_params_file;
+            std::map<lt::info_hash_t, std::tuple<lt::torrent_handle, lt::torrent_status>> torrents;
 
             void Recheck(const lt::info_hash_t& hash);
 


### PR DESCRIPTION
Instead of calling `.status()` on the torrent_handle - cache our view of it and use that in all the RPC methods and APIs. This should provide a nice performance increase when dealing with a large number of torrents (think 100k).