### PR TITLE
feat(web): add columns for peers and seeds

### DIFF
--- a/html/src/components/TorrentsList.tsx
+++ b/html/src/components/TorrentsList.tsx
@@ -74,7 +74,7 @@ export default function TorrentsList(props: TorrentsListProps) {
       spacing={1}
     >
       <Grid
-        gridTemplateColumns={"32px 48px 1fr 100px 110px 110px 100px 48px"}
+        gridTemplateColumns={"32px 48px 1fr 100px 110px 110px 110px 110px 100px 48px"}
         gridTemplateRows={"0fr"}
       >
         <GridItem></GridItem>
@@ -95,6 +95,12 @@ export default function TorrentsList(props: TorrentsListProps) {
         </GridItem>
         <GridItem display={"flex"} me={2} justifyContent={"end"}>
           <GridTitle field={"upload_rate"} onSort={props.onSort} orderBy={props.orderBy} orderByDir={props.orderByDir} title="UL" />
+        </GridItem>
+        <GridItem display={"flex"} me={2} justifyContent={"end"}>
+          <GridTitle field={"num_seeds"} onSort={props.onSort} orderBy={props.orderBy} orderByDir={props.orderByDir} title="Seeds" />
+        </GridItem>
+        <GridItem display={"flex"} me={2} justifyContent={"end"}>
+          <GridTitle title="Peers" />
         </GridItem>
         <GridItem></GridItem>
       </Grid>

--- a/html/src/components/TorrentsListItem.tsx
+++ b/html/src/components/TorrentsListItem.tsx
@@ -160,7 +160,7 @@ export default function TorrentsListItem(props: TorrentsListItemProps) {
 
   return (
     <Grid
-      gridTemplateColumns={"32px 48px 1fr 100px 110px 110px 100px 48px"}
+      gridTemplateColumns={"32px 48px 1fr 100px 110px 110px 110px 110px 100px 48px"}
       gridTemplateRows={"min-content"}
     >
       <GridItem alignSelf={"center"}>
@@ -318,6 +318,32 @@ export default function TorrentsListItem(props: TorrentsListItemProps) {
             ? <>{filesize(props.torrent.upload_rate).toString()}/s</>
             : <>-</>
           }
+        </Text>
+      </GridItem>
+
+      <GridItem alignSelf={"center"} textAlign={"end"}>
+        <Text
+          fontSize={"sm"}
+          mx={2}
+        >
+          {props.torrent.num_seeds} ({
+          props.torrent.num_complete > -1 ?
+              props.torrent.num_complete :
+              props.torrent.list_seeds
+        })
+        </Text>
+      </GridItem>
+
+      <GridItem alignSelf={"center"} textAlign={"end"}>
+        <Text
+          fontSize={"sm"}
+          mx={2}
+        >
+          {props.torrent.num_peers - props.torrent.num_seeds} ({
+          props.torrent.num_incomplete > -1 ?
+              props.torrent.num_incomplete :
+              props.torrent.list_peers - props.torrent.list_seeds
+        })
         </Text>
       </GridItem>
 

--- a/html/src/types/index.tsx
+++ b/html/src/types/index.tsx
@@ -17,6 +17,12 @@ export type Torrent = {
   category: string | null;
   download_rate: number;
   download_limit: number;
+  num_peers: number;
+  num_seeds: number;
+  num_complete: number;
+  num_incomplete: number;
+  list_peers: number;
+  list_seeds: number;
   error: any;
   eta: number;
   flags: string[];

--- a/src/methods/torrentslist.cpp
+++ b/src/methods/torrentslist.cpp
@@ -237,6 +237,8 @@ void TorrentsList::Invoke(const TorrentsListReq& req, WriteCb<TorrentsListRes> c
                 .name              = ts.name,
                 .num_peers         = ts.num_peers,
                 .num_seeds         = ts.num_seeds,
+                .num_complete      = ts.num_complete,
+                .num_incomplete    = ts.num_incomplete,
                 .progress          = ts.progress,
                 .queue_position    = static_cast<int>(ts.queue_position),
                 .ratio             = porla::Utils::Ratio(ts),

--- a/src/methods/torrentslist_reqres.hpp
+++ b/src/methods/torrentslist_reqres.hpp
@@ -41,6 +41,8 @@ namespace porla::Methods
             std::string                     name;
             int                             num_peers;
             int                             num_seeds;
+            int                             num_complete;
+            int                             num_incomplete;
             float                           progress;
             int                             queue_position;
             double                          ratio;


### PR DESCRIPTION
Adding two more columns in web-ui stats: Seeds and Peers.
Displaying connected seeds with total torrent seeds in parenthesis and connected leechers  with total leeches in parenthesis.

Exactly as it's done in qBittorrent (relevant sources [here](https://github.com/qbittorrent/qBittorrent/blob/bb8a012b1ca6350b134df11280abea42929cb528/src/base/bittorrent/torrentimpl.cpp#L1336)).

Named leeches as "Peers" as in qBittorrent and other clients.