### PR TITLE
feat: allow hiding presets in the ui

### DIFF
--- a/html/src/components/AddTorrentModal.tsx
+++ b/html/src/components/AddTorrentModal.tsx
@@ -54,7 +54,12 @@ type AddTorrentModalProps = {
 }
 
 export default function AddTorrentModal(props: AddTorrentModalProps) {
-  const { presets } = props;
+  const presets = Object.keys(props.presets)
+    .filter(presetName => !props.presets[presetName]["$hidden"])
+    .reduce((prev, curr) => {
+      prev[curr] = props.presets[curr];
+      return prev;
+    }, {} as PresetsList);
 
   const fsSpace             = useInvoker<any>("fs.space");
   const torrentsAdd         = useInvoker<InfoHash>("torrents.add");
@@ -221,7 +226,7 @@ export default function AddTorrentModal(props: AddTorrentModalProps) {
                           }}
                         >
                           { Object.keys(presets).map(p => (
-                            <option key={p} selected={p === values.preset}>{p}</option>
+                            <option key={p} value={p}>{p}</option>
                           ))}
                         </Select>
                         <FormHelperText>Select a preset to apply to the torrent.</FormHelperText>

--- a/html/src/types/index.tsx
+++ b/html/src/types/index.tsx
@@ -8,7 +8,8 @@ export type PresetsList = {
 };
 
 export type Preset = {
-  save_path: string | null
+  save_path: string | null;
+  $hidden: boolean | null;
 };
 
 export type Torrent = {

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -292,6 +292,9 @@ std::unique_ptr<Config> Config::Load(const boost::program_options::variables_map
                     if (auto val = value_tbl["upload_limit"].value<int>())
                         p.upload_limit = *val;
 
+                    if (auto dollar_hidden = value_tbl["$hidden"].value<bool>())
+                        p.dollar_hidden = *dollar_hidden;
+
                     cfg->presets.insert({ key.data(), std::move(p) });
                 }
             }

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -33,6 +33,9 @@ namespace porla
             std::optional<libtorrent::storage_mode_t> storage_mode;
             std::unordered_set<std::string>           tags;
             std::optional<int>                        upload_limit;
+
+            // porla specific
+            std::optional<bool>                       dollar_hidden;
         };
 
         std::optional<std::string>               config_file;

--- a/src/json/presetslist.hpp
+++ b/src/json/presetslist.hpp
@@ -27,6 +27,9 @@ namespace porla::Methods
             j[key]["session"]         = preset.session         ? json(preset.session.value())         : json();
             j[key]["tags"]            = !preset.tags.empty()   ? json(preset.tags)                    : json();
             j[key]["upload_limit"]    = preset.upload_limit    ? json(preset.upload_limit.value())    : json();
+
+            // porla specific
+            j[key]["$hidden"]         = preset.dollar_hidden   ? json(preset.dollar_hidden.value())   : json();
         }
     }
 }


### PR DESCRIPTION
By setting the `$hidden` key on a preset, it hides the preset from the UI.

```toml
[preset.foo]
"$hidden" = true
```

Closes #265