### PR TITLE
feat(http): add torrents.overview jsonrpc method

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,6 +113,7 @@ add_library(
     src/methods/torrentsresume.cpp
     src/methods/torrentspropertiesset.cpp
     src/methods/torrentstrackerslist.cpp
+    src/methods/torrents/torrentsoverview.cpp
     src/methods/webui/webuiinstall.cpp
 
     src/query/_aux/PorlaQueryLangBaseVisitor.cpp

--- a/src/json/all.hpp
+++ b/src/json/all.hpp
@@ -23,6 +23,7 @@
 #include "torrentslist.hpp"
 #include "torrentsmetadatalist.hpp"
 #include "torrentsmove.hpp"
+#include "torrentsoverview.hpp"
 #include "torrentspause.hpp"
 #include "torrentspeersadd.hpp"
 #include "torrentspeerslist.hpp"

--- a/src/json/torrentsoverview.hpp
+++ b/src/json/torrentsoverview.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <nlohmann/json.hpp>
+
+#include "utils.hpp"
+#include "../methods/torrents/torrentsoverview_reqres.hpp"
+
+namespace porla::Methods::Torrents
+{
+    static void from_json(const nlohmann::json& j, TorrentsOverviewReq& res)
+    {
+    }
+
+    NLOHMANN_JSONIFY_ALL_THINGS(
+        TorrentsOverviewSession,
+        torrents_per_category,
+        torrents_per_state,
+        torrents_per_tag,
+        torrents_per_tracker,
+        torrents_total);
+
+    NLOHMANN_JSONIFY_ALL_THINGS(
+        TorrentsOverviewRes,
+        sessions);
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -52,6 +52,7 @@
 #include "methods/torrentspropertiesget.hpp"
 #include "methods/torrentspropertiesset.hpp"
 #include "methods/torrentstrackerslist.hpp"
+#include "methods/torrents/torrentsoverview.hpp"
 #include "methods/webui/webuiinstall.hpp"
 
 int main(int argc, char* argv[])
@@ -184,6 +185,7 @@ int main(int argc, char* argv[])
             {"torrents.list", porla::Methods::TorrentsList(sessions)},
             {"torrents.metadata.list", porla::Methods::TorrentsMetadataList(cfg->db, sessions)},
             {"torrents.move", porla::Methods::TorrentsMove(sessions)},
+            {"torrents.overview", porla::Methods::Torrents::TorrentsOverview(sessions)},
             {"torrents.pause", porla::Methods::TorrentsPause(sessions)},
             {"torrents.peers.add", porla::Methods::TorrentsPeersAdd(sessions)},
             {"torrents.peers.list", porla::Methods::TorrentsPeersList(sessions)},

--- a/src/methods/torrents/torrentsoverview.cpp
+++ b/src/methods/torrents/torrentsoverview.cpp
@@ -1,0 +1,83 @@
+#include "torrentsoverview.hpp"
+
+#include "../../sessions.hpp"
+#include "../../torrentclientdata.hpp"
+
+using porla::Methods::Torrents::TorrentsOverview;
+
+TorrentsOverview::TorrentsOverview(porla::Sessions& sessions)
+    : m_sessions(sessions)
+{
+}
+
+void TorrentsOverview::Invoke(const TorrentsOverviewReq& req, WriteCb<TorrentsOverviewRes> cb)
+{
+    TorrentsOverviewRes res = {};
+
+    for (const auto& [ session, state ] : m_sessions.All())
+    {
+        TorrentsOverviewSession sess{
+            .torrents_total = state->torrents.size()
+        };
+
+        for (const auto& [ _, torrent ] : state->torrents)
+        {
+            const auto& handle = std::get<lt::torrent_handle>(torrent);
+            const auto data = handle.userdata().get<TorrentClientData>();
+
+            if (data->category.has_value())
+            {
+                if (!sess.torrents_per_category.contains(data->category.value()))
+                {
+                    sess.torrents_per_category.insert({ data->category.value(), 0 });
+                }
+
+                sess.torrents_per_category.at(data->category.value())++;
+            }
+
+            if (!data->tags.empty())
+            {
+                for (const auto& tag : data->tags)
+                {
+                    if (!sess.torrents_per_tag.contains(tag))
+                    {
+                        sess.torrents_per_tag.insert({ tag, 0 });
+                    }
+
+                    sess.torrents_per_tag.at(tag)++;
+                }
+            }
+
+            const auto& ts = handle.status();
+
+            std::string state = "unknown";
+            if (ts.state == lt::torrent_status::checking_files)            state = "checking_files";
+            else if (ts.state == lt::torrent_status::downloading_metadata) state = "downloading_metadata";
+            else if (ts.state == lt::torrent_status::downloading)          state = "downloading";
+            else if (ts.state == lt::torrent_status::finished)             state = "finished";
+            else if (ts.state == lt::torrent_status::seeding)              state = "seeding";
+            else if (ts.state == lt::torrent_status::checking_resume_data) state = "checking_resume_data";
+
+            if (!sess.torrents_per_state.contains(state))
+            {
+                sess.torrents_per_state.insert({ state, 0 });
+            }
+
+            sess.torrents_per_state.at(state)++;
+
+            for (const auto& entry : handle.trackers())
+            {
+                if (!sess.torrents_per_tracker.contains(entry.url))
+                {
+                    sess.torrents_per_tracker.insert({ entry.url, 0 });
+                }
+
+                sess.torrents_per_tracker.at(entry.url)++;
+            }
+        }
+
+        res.sessions.insert({ session, sess });
+    }
+
+    cb.Ok(res);
+}

--- a/src/methods/torrents/torrentsoverview.hpp
+++ b/src/methods/torrents/torrentsoverview.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "../method.hpp"
+#include "torrentsoverview_reqres.hpp"
+
+namespace porla
+{
+    class Sessions;
+}
+
+namespace porla::Methods::Torrents
+{
+    class TorrentsOverview : public Method<TorrentsOverviewReq, TorrentsOverviewRes>
+    {
+    public:
+        explicit TorrentsOverview(porla::Sessions& sessions);
+
+        void Invoke(const TorrentsOverviewReq& req, WriteCb<TorrentsOverviewRes> cb) override;
+
+    private:
+        porla::Sessions& m_sessions;
+    };
+}

--- a/src/methods/torrents/torrentsoverview_reqres.hpp
+++ b/src/methods/torrents/torrentsoverview_reqres.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <map>
+#include <string>
+
+#include <stdint.h>
+
+namespace porla::Methods::Torrents
+{
+    struct TorrentsOverviewReq
+    {
+    };
+
+    struct TorrentsOverviewSession
+    {
+        std::map<std::string, std::uint64_t> torrents_per_category;
+        std::map<std::string, std::uint64_t> torrents_per_state;
+        std::map<std::string, std::uint64_t> torrents_per_tag;
+        std::map<std::string, std::uint64_t> torrents_per_tracker;
+        std::uint64_t                        torrents_total;
+    };
+
+    struct TorrentsOverviewRes
+    {
+        std::map<std::string, TorrentsOverviewSession> sessions;
+    };
+}


### PR DESCRIPTION
A method to get an overview of how many torrents are in different states,

```json
{
    "id": null,
    "jsonrpc": "2.0",
    "result": {
        "sessions": {
            "default": {
                "torrents_per_category": {},
                "torrents_per_state": {
                    "seeding": 3
                },
                "torrents_per_tag": {},
                "torrents_per_tracker": {
                    "http://bttracker.debian.org:6969/announce": 3
                },
                "torrents_total": 3
            }
        }
    }
}
```